### PR TITLE
README cleanup. Fix maven build warning

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,12 @@
+# WebGoat: A deliberately insecure Web Application
+
+[![Build Status](https://travis-ci.org/WebGoat/WebGoat.svg)](https://travis-ci.org/WebGoat/WebGoat)
+
 # Important Information
 
 Thank you for downloading WebGoat! This is the WebGoat Lesson Server version which is currently under development.
+
+WebGoat is a deliberately insecure web application maintained by [OWASP](http://www.owasp.org/) designed to teach web application security lessons.
 
 This program is a demonstration of common server-side application flaws. The
 exercises are intended to be used by people to learn about application
@@ -12,8 +18,8 @@ penetration testing techniques.
 * [Easy-Run Download](https://webgoat.atlassian.net/builds/browse/WEB-CNTNR)
 * [Wiki](https://github.com/WebGoat/WebGoat/wiki)
 * [FAQ (old info):](http://code.google.com/p/webgoat/wiki/FAQ)
-* [Contact Info - Direct to Bruce Mayhew](webgoat@owasp.org)
-* [Mailing List - WebGoat Community - For most questions](owasp-webgoat@lists.owasp.org) 
+* [Project Leader - Direct to Bruce Mayhew](mailto:webgoat@owasp.org)
+* [Mailing List - WebGoat Community - For most questions](mailto:owasp-webgoat@lists.owasp.org)
 
 **WARNING 1:** *While running this program your machine will be extremely
 vulnerable to attack. You should to disconnect from the Internet while using
@@ -33,7 +39,7 @@ You can find more information about WebGoat at:
 
 Follow these instructions if you simply wish to run WebGoat
 
-**Prerequisites:** 
+**Prerequisites:**
 
 Java VM >= 1.6 installed ( JDK 1.7 recommended)
 
@@ -43,26 +49,29 @@ Java VM >= 1.6 installed ( JDK 1.7 recommended)
 
 2. Run it using java:
 
-    > java -jar WebGoat-6.0-exec-war.jar
+```Shell
+$ java -jar WebGoat-6.0-exec-war.jar
+```
 
 3. Then navigate in your browser to: (http://localhost:8080/WebGoat)
 
 4. If you would like to change the port or other options, use:
 
-    > java -jar WebGoat-6.0-exec-war.jar --help
-
+```Shell
+$ java -jar WebGoat-6.0-exec-war.jar --help
+```
 
 # For Developers
 
 Follow these instructions if you wish to run Webgoat and modify the source code as well.
 
 **Prerequisites:**
-
+/
 * Java >= 1.6 ( JDK 1.7 recommended )
 * Maven > 2.0.9
 * Your favorite IDE, with Maven awareness: Netbeans/IntelliJ/Eclipse with m2e installed.
 * Git, or Git support in your IDE
-        
+
 **Note:** WebGoat source code can be downloaded at: (https://github.com/WebGoat/WebGoat).
 
 
@@ -70,34 +79,39 @@ Follow these instructions if you wish to run Webgoat and modify the source code 
 
 Using a command shell/window:
 
-   > mvn clean package
+```Shell
+$ mvn clean package
+```
 
 Before you can run the project you need to build some lessons first clone https://github.com/WebGoat/WebGoat-Lessons and run:
 
-    ```
-    $ cd WebGoat-Lessons
-    $ mvn package
-    $ cp plugins/* <tomcat>/webapps/WebGoat-6.0-exec-war/plugin_lessons/
-    ```
+```Shell
+  $ cd WebGoat-Lessons
+  $ mvn package
+  $ cp plugins/* <tomcat>/webapps/WebGoat-6.0-exec-war/plugin_lessons/
+```
 
 Then you can run the project with one of the steps below:
 
 1. Maven-Tomcat Plugin
    using a command shell/window:
 
-   > mvn -pl webgoat-container tomcat7:run-war
-
+```Shell
+$ mvn -pl webgoat-container tomcat7:run-war
+```
 
 Maven will run the project in an embedded tomcat.
 
 2. Java JAR
    the package phase also builds an executable jar file. You can run it using:
 
-```
-   $ cd target
-   $ java -jar WebGoat-6.0-exec-war.jar http://localhost:8080/WebGoat
+```Shell
+$ cd target
+$ java -jar WebGoat-6.0-exec-war.jar http://localhost:8080/WebGoat
 ```
 
 3. Tomcat the package phase also builds a war file. You can deploy it using:
 
-    > cp target/WebGoat-6.0-exec-war.war <tomcat>/webapps/
+```Shell
+$ cp target/WebGoat-6.0-exec-war.war <tomcat>/webapps/
+```

--- a/README.MD
+++ b/README.MD
@@ -4,7 +4,9 @@
 
 # Important Information
 
-Thank you for downloading WebGoat! This is the WebGoat Lesson Server version which is currently under development.
+### This is a work in progress of the WebGoat Lesson Server, which is currently **UNDER MAJOR DEVELOMENT**
+
+#### Current stable version and instructions can be found at:  [WebGoat-Legacy](https://github.com/WebGoat/WebGoat-Legacy)
 
 WebGoat is a deliberately insecure web application maintained by [OWASP](http://www.owasp.org/) designed to teach web application security lessons.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <name>webgoat-parent</name>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.owasp.webgoat</groupId>  
-    <artifactId>webgoat-parent</artifactId>
-    <packaging>pom</packaging>
-    <version>6.1.0</version>
-
-    <!-- Shared version number properties -->
-    <properties>
-        <!-- If run from Bamboo this will be replaced with the bamboo build number -->
-        <build.number>local</build.number>
-    </properties>
-    <modules>
-	<module>webgoat-container</module>
-	<module>webgoat-classloader</module>
-	<!-- <module>webgoat-release</module> -->
-	</modules>
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <name>webgoat-parent</name>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.owasp.webgoat</groupId>
+  <artifactId>webgoat-parent</artifactId>
+  <packaging>pom</packaging>
+  <version>7.0-SNAPSHOT</version>
+  <!-- Shared version number properties -->
+  <properties>
+    <!-- If run from Bamboo this will be replaced with the bamboo build number -->
+    <build.number>local</build.number>
+  </properties>
+  <modules>
+    <module>webgoat-container</module>
+    <module>webgoat-classloader</module>
+    <!-- <module>webgoat-release</module> -->
+  </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <!-- If run from Bamboo this will be replaced with the bamboo build number -->
     <build.number>local</build.number>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <modules>
     <module>webgoat-container</module>

--- a/webgoat-classloader/pom.xml
+++ b/webgoat-classloader/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.owasp.webgoat</groupId>
         <artifactId>webgoat-parent</artifactId>
-        <version>6.1.0</version>
+        <version>7.0-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>27</version>
+                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>create-jar</id>

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -98,7 +98,8 @@
                 <artifactId>tomcat7-maven-plugin</artifactId>
                 <version>2.1</version>
                 <configuration>
-                    <url>http://localhost:8080/manager</url>
+                  <server>local_tomcat</server>
+                  <url>http://localhost:8080/manager/text</url>
                     <path>/WebGoat</path>
                     <attachArtifactClassifier>exec</attachArtifactClassifier>
                     <contextReloadable>true</contextReloadable>

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.owasp.webgoat</groupId>
         <artifactId>webgoat-parent</artifactId>
-        <version>6.1.0</version>
+        <version>7.0-SNAPSHOT</version>
     </parent>
 
 

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -41,6 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>27</version>
                 <executions>
                     <execution>
                         <id>create-jar</id>
@@ -108,7 +109,7 @@
                     <dependency>
                         <groupId>org.owasp.webgoat</groupId>
                         <artifactId>webgoat-classloader</artifactId>
-                        <version>6.1.0</version>
+                        <version>${project.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.owasp.webgoat</groupId>
@@ -180,11 +181,6 @@
             <version>3.3.2</version>
         </dependency>
         <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <version>1.2.1</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>1.4</version>
@@ -235,12 +231,6 @@
             <artifactId>hsqldb</artifactId>
             <version>1.8.0.10</version>
         </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-
         <dependency>
             <groupId>wsdl4j</groupId>
             <artifactId>wsdl4j</artifactId>
@@ -333,13 +323,6 @@
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <version>1.2.2</version>
-        </dependency>
-
-        <!-- Apache Commons Upload -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
         </dependency>
 
         <dependency>

--- a/webgoat-release/pom.xml
+++ b/webgoat-release/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.owasp.webgoat</groupId>
         <artifactId>webgoat-parent</artifactId>
-        <version>6.1.0</version>
+        <version>7.0-SNAPSHOT</version>
     </parent>
 
     <!-- Shared version number properties -->


### PR DESCRIPTION
**Updated artifact versions to 7.0-SNAPSHOT**

README.md changes: Fixed some formatting issues with the README, added a Travis CI Build Badge, as it can be seen on my fork --> https://github.com/dougmorato/WebGoat .

pom.xml changes : Cleaned up th duplicate dependencies in the POMs, fixed all the build warnings given from maven.
