### PR TITLE
Fixed not serializable error when stopping/starting Tomcat

### DIFF
--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelManagerImpl.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelManagerImpl.java
@@ -1,11 +1,13 @@
 
 package org.owasp.webgoat.util;
 
-import java.util.Locale;
-import javax.annotation.Resource;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.io.Serializable;
+import java.util.Locale;
 
 
 /***************************************************************************************************
@@ -37,13 +39,19 @@ import org.springframework.stereotype.Component;
  */
 @Component("labelManager")
 @Scope(value="session", proxyMode=ScopedProxyMode.INTERFACES)
-public class LabelManagerImpl implements LabelManager
+public class LabelManagerImpl implements LabelManager, Serializable
 {
-	@Resource
-	private LabelProvider labelProvider;
+	private transient LabelProvider labelProvider;
 
 	/** Locale mapped with current session. */
 	private Locale locale = new Locale(LabelProvider.DEFAULT_LANGUAGE);
+
+	protected LabelManagerImpl() {}
+
+	@Inject
+	public LabelManagerImpl(LabelProvider labelProvider) {
+		this.labelProvider = labelProvider;
+	}
 
 	public void setLocale(Locale locale)
 	{

--- a/webgoat-container/src/test/java/org/owasp/webgoat/util/LabelManagerImplTest.java
+++ b/webgoat-container/src/test/java/org/owasp/webgoat/util/LabelManagerImplTest.java
@@ -1,0 +1,26 @@
+package org.owasp.webgoat.util;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+public class LabelManagerImplTest {
+
+    @Test
+    public void shouldSerialize() throws IOException {
+        LabelManagerImpl labelManager = new LabelManagerImpl(null);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(bos);
+        out.writeObject(labelManager);
+    }
+
+    @Test
+    public void shouldSerializeWithLabelProvider() throws IOException {
+        LabelManagerImpl labelManager = new LabelManagerImpl(new LabelProvider());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(bos);
+        out.writeObject(labelManager);
+    }
+}


### PR DESCRIPTION
Issue when Tomcat is starting or stopping the session is serialized. This class caused an error because it did not implement Serializable. 

NOTE: make sure you first do a `mvn clean` before starting Tomcat again because of old session caching in the `target` directory. Maybe best to put a message on slack when this is merged.