### PR TITLE
Do NOT run Integration tests on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ jdk:
   - oraclejdk8
 install: "/bin/true"
 script:
-  - mvn clean compile install
+  - mvn clean install
   - git clone https://github.com/WebGoat/WebGoat-Lessons.git
   - mvn -file ./WebGoat-Lessons/pom.xml package
   - cp -fa ./WebGoat-Lessons/target/plugins/*.jar ./webgoat-container/src/main/webapp/plugin_lessons/
-  - if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then mvn -Prun-integration-tests package verify install; else mvn package install; fi
+  - if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then mvn -Prun-integration-tests clean install; else mvn clean install; fi
 before_deploy:
   - export WEBGOAT_ARTIFACT_VERSION=$(grep "<version>" $HOME/build/$TRAVIS_REPO_SLUG/pom.xml | cut -d ">" -f 2 | cut -d "<" -f 1)
   - export WEBGOAT_JAR_FILE=$HOME/build/$TRAVIS_REPO_SLUG/webgoat-container/target/webgoat-container-$WEBGOAT_ARTIFACT_VERSION.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - git clone https://github.com/WebGoat/WebGoat-Lessons.git
   - mvn -file ./WebGoat-Lessons/pom.xml package
   - cp -fa ./WebGoat-Lessons/target/plugins/*.jar ./webgoat-container/src/main/webapp/plugin_lessons/
-  - mvn -Prun-integration-tests package verify install
+  - if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then mvn -Prun-integration-tests package verify install; else mvn package install; fi
 before_deploy:
   - export WEBGOAT_ARTIFACT_VERSION=$(grep "<version>" $HOME/build/$TRAVIS_REPO_SLUG/pom.xml | cut -d ">" -f 2 | cut -d "<" -f 1)
   - export WEBGOAT_JAR_FILE=$HOME/build/$TRAVIS_REPO_SLUG/webgoat-container/target/webgoat-container-$WEBGOAT_ARTIFACT_VERSION.jar
@@ -36,7 +36,6 @@ deploy:
     jdk: oraclejdk8
 notifications:
   slack:
-    rooms:
-      secure: "RS/QCVjDAt8y7c816d8UIJUl2OLaRRU6gjh//7Kb4f9TyKRACtP0Qa9NVNhSXuvb2kzUTOFb76Lz8utnt2a3iZ+elZMvnQu8+HioKr9wWJPKml8TLC+tCclQnSAz7orsQ0ubgUlsVycs7bsaQ79aKw1C9YdH+QNDgMKDxvfrEKk="
+    secure: S9VFew5NSE8WDzYD1VDBUULKKT0fzgblQACznwQ85699b2yeX9TX58N3RZvRS1JVagVP1wu2xOrwN2g+AWx4Ro3UBZD5XG86uTJWpCLD4cRWHBoGMH2TfvI7/IzsWmgxH4MBxFRvZr/eEhlVAux+N9H4EoEdS4CKsJXEqV37PlA=
 addons:
   sauce_connect: true


### PR DESCRIPTION
Because we are using Sauce Labs, which requires a secret key to connect with the Sauce Labs server, in order to protect the secret key, this secret key is not made available to the TravisCI Virtual Machines during pull requests.

This change DISABLE the integration testing when build is triggered from a pull request.

I will try to find other ways to perform integration tests securely on pull requests, but as of know, this PR is important to keep our builds from failing.

