### PR TITLE
Pom refactoring, javadocs compliance and Integration improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,11 @@
     <inceptionYear>2006</inceptionYear>
     <url>https://github.com/WebGoat/WebGoat</url>
 
+    <organization>
+        <name>OWASP</name>
+        <url>https://webgoat.github.io/</url>
+    </organization>
+
     <licenses>
         <license>
             <name>GNU General Public License, version 2</name>
@@ -59,6 +64,10 @@
             <email>doug.morato@owasp.org</email>
             <organization>OWASP</organization>
             <organizationUrl>https://github.com/dougmorato</organizationUrl>
+            <timezone>America/New_York</timezone>
+            <properties>
+                <picUrl>https://avatars2.githubusercontent.com/u/9654?v=3&amp;s=150</picUrl>
+            </properties>
         </developer>
     </developers>
 
@@ -83,11 +92,18 @@
         <url>https://github.com/WebGoat/WebGoat/issues</url>
     </issueManagement>
 
+    <ciManagement>
+        <system>Travis CI</system>
+        <url>https://travis-ci.org/WebGoat/WebGoat</url>
+    </ciManagement>
+
     <properties>
         <!-- Use UTF-8 Encoding -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+        <!-- This build number will be ubdated by Travis-CI -->
+        <build.number>build</build.number>
 
         <!-- Shared properties with plugins and version numbers across submodules-->
         <activation.version>1.1</activation.version>
@@ -120,8 +136,10 @@
         <mail.version>1.4.2</mail.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+        <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
         <maven-war-plugin.version>2.4</maven-war-plugin.version>
@@ -150,45 +168,83 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${nexus-staging-maven-plugin.version}</version>
-                <extensions>true</extensions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <goals>deploy</goals>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>${maven-source-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,194 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <name>webgoat-parent</name>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.owasp.webgoat</groupId>
-  <artifactId>webgoat-parent</artifactId>
-  <packaging>pom</packaging>
-  <version>7.0-SNAPSHOT</version>
-  <!-- Shared version number properties -->
-  <properties>
-    <!-- If run from Bamboo this will be replaced with the bamboo build number -->
-    <build.number>local</build.number>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-  <modules>
-    <module>webgoat-container</module>
-    <module>webgoat-classloader</module>
-  </modules>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.owasp.webgoat</groupId>
+    <artifactId>webgoat-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>7.0-SNAPSHOT</version>
+
+    <name>WebGoat Parent Pom</name>
+    <description>Parent Pom for the WebGoat Project. A deliberately insecure Web Application</description>
+    <inceptionYear>2006</inceptionYear>
+    <url>https://github.com/WebGoat/WebGoat</url>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License, version 2</name>
+            <url>https://www.gnu.org/licenses/gpl-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>mayher64</id>
+            <name>Bruce Mayhew</name>
+            <email>webgoat@owasp.org</email>
+            <organization>OWASP</organization>
+            <organizationUrl>https://github.com/WebGoat/WebGoat</organizationUrl>
+        </developer>
+        <developer>
+            <id>nnbaars</id>
+            <name>Nanne Baars</name>
+            <email></email>
+        </developer>
+        <developer>
+            <id>misfir3</id>
+            <name></name>
+            <email></email>
+        </developer>
+        <developer>
+            <id>jwayman</id>
+            <name>Jeff Wayman</name>
+            <email></email>
+        </developer>
+        <developer>
+            <id>dcowden</id>
+            <name>Dave Cowden</name>
+            <email></email>
+        </developer>
+        <developer>
+            <id>lawson89</id>
+            <name>Richard Lawson</name>
+            <email></email>
+        </developer>
+        <developer>
+            <id>dougmorato</id>
+            <name>Doug Morato</name>
+            <email>doug.morato@owasp.org</email>
+            <organization>OWASP</organization>
+            <organizationUrl>https://github.com/dougmorato</organizationUrl>
+        </developer>
+    </developers>
+
+    <mailingLists>
+        <mailingList>
+            <name>OWASP WebGoat Mailing List</name>
+            <subscribe>https://lists.owasp.org/mailman/listinfo/owasp-webgoat</subscribe>
+            <unsubscribe>Owasp-webgoat-request@lists.owasp.org</unsubscribe>
+            <post>owasp-webgoat@lists.owasp.org</post>
+            <archive>http://lists.owasp.org/pipermail/owasp-webgoat/</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm>
+        <url>https://github.com/WebGoat/WebGoat</url>
+        <connection>scm:git:git@github.com:WebGoat/WebGoat.git</connection>
+        <developerConnection>scm:git:git@github.com:WebGoat/WebGoat.git</developerConnection>
+    </scm>
+
+    <issueManagement>
+        <system>Github Issues</system>
+        <url>https://github.com/WebGoat/WebGoat/issues</url>
+    </issueManagement>
+
+    <properties>
+        <!-- Use UTF-8 Encoding -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+
+        <!-- Shared properties with plugins and version numbers across submodules-->
+        <activation.version>1.1</activation.version>
+        <axis-ant.version>1.2</axis-ant.version>
+        <axis-jaxrpc.version>1.2</axis-jaxrpc.version>
+        <axis-saaj.version>1.2</axis-saaj.version>
+        <axis.version>1.2</axis.version>
+        <build-helper-maven-plugin.version>1.7</build-helper-maven-plugin.version>
+        <commons-collections.version>3.1</commons-collections.version>
+        <commons-digester.version>1.8.1</commons-digester.version>
+        <commons-discovery.version>0.2</commons-discovery.version>
+        <commons-fileupload.version>1.2.2</commons-fileupload.version>
+        <commons-io.version>1.4</commons-io.version>
+        <commons-lang3.version>3.3.2</commons-lang3.version>
+        <commons-logging.version>1.1.3</commons-logging.version>
+        <ecs.version>1.4.2</ecs.version>
+        <guava.version>18.0</guava.version>
+        <h2.version>1.4.187</h2.version>
+        <hsqldb.version>1.8.0.10</hsqldb.version>
+        <j2h.version>1.3.1</j2h.version>
+        <jackson-core.version>2.0.4</jackson-core.version>
+        <jackson-databind.version>2.0.4</jackson-databind.version>
+        <javaee-api.version>6.0</javaee-api.version>
+        <javax.transaction-api.version>1.2</javax.transaction-api.version>
+        <jcl-over-slf4j.version>1.7.7</jcl-over-slf4j.version>
+        <jstl.version>1.2</jstl.version>
+        <jtds.version>1.2.2</jtds.version>
+        <junit.version>4.12</junit.version>
+        <log4j.version>1.2.17</log4j.version>
+        <mail.version>1.4.2</mail.version>
+        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+        <maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
+        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>2.4</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
+        <maven-war-plugin.version>2.4</maven-war-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.6</nexus-staging-maven-plugin.version>
+        <org.springframework.version>3.2.4.RELEASE</org.springframework.version>
+        <sauce_junit.version>2.1.18</sauce_junit.version>
+        <selenium-java.version>2.47.1</selenium-java.version>
+        <slf4j-api.version>1.7.7</slf4j-api.version>
+        <slf4j-log4j12.version>1.7.7</slf4j-log4j12.version>
+        <spring.security.version>3.2.4.RELEASE</spring.security.version>
+        <standard.version>1.1.2</standard.version>
+        <tiles.version>2.2.2</tiles.version>
+        <tomcat7-maven-plugin.version>2.2</tomcat7-maven-plugin.version>
+        <wsdl4j.version>1.5.1</wsdl4j.version>
+        <tomcat-catalina.version>7.0.63</tomcat-catalina.version>
+    </properties>
+
+    <modules>
+        <module>webgoat-container</module>
+        <module>webgoat-classloader</module>
+    </modules>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/webgoat-classloader/pom.xml
+++ b/webgoat-classloader/pom.xml
@@ -1,9 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <name>webgoat-classloader</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webgoat-classloader</artifactId>
     <packaging>jar</packaging>
+
     <parent>
         <groupId>org.owasp.webgoat</groupId>
         <artifactId>webgoat-parent</artifactId>
@@ -15,7 +18,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -29,9 +32,8 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>7.0.47</version>
+            <version>${tomcat-catalina.version}</version>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/webgoat-classloader/src/main/java/org/owasp/webgoat/classloader/PluginClassLoader.java
+++ b/webgoat-classloader/src/main/java/org/owasp/webgoat/classloader/PluginClassLoader.java
@@ -14,15 +14,30 @@ import java.util.List;
  *
  * With this loader we can add jars we load during the plugin loading and the jsp will pick it up because this is
  * the same classloader.
+ *
+ * @version $Id: $Id
  */
 public class PluginClassLoader extends WebappClassLoader {
+    /**
+     * <p>Constructor for PluginClassLoader.</p>
+     */
     public PluginClassLoader() {
     }
 
+    /**
+     * <p>Constructor for PluginClassLoader.</p>
+     *
+     * @param parent a {@link java.lang.ClassLoader} object.
+     */
     public PluginClassLoader(ClassLoader parent) {
         super(parent);
     }
 
+    /**
+     * <p>addURL.</p>
+     *
+     * @param urls a {@link java.util.List} object.
+     */
     public void addURL(List<URL> urls) {
         for (URL url : urls) {
             super.addURL(url);

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -1,22 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <name>webgoat-container</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webgoat-container</artifactId>
     <packaging>war</packaging>
+
     <parent>
         <groupId>org.owasp.webgoat</groupId>
         <artifactId>webgoat-parent</artifactId>
         <version>7.0-SNAPSHOT</version>
     </parent>
-
-
-    <!-- Shared version number properties -->
-    <properties>
-        <org.springframework.version>3.2.4.RELEASE</org.springframework.version>
-        <spring.security.version>3.2.4.RELEASE</spring.security.version>
-        <tiles.version>2.2.2</tiles.version>
-    </properties>
 
     <profiles>
         <profile>
@@ -33,7 +28,7 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
-                        <version>2.2</version>
+                        <version>${tomcat7-maven-plugin.version}</version>
                         <configuration>
                             <server>local_tomcat</server>
                             <url>http://localhost:8080/manager</url>
@@ -96,7 +91,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.18.1</version>
+                        <version>${maven-failsafe-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -124,7 +119,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -134,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>${maven-jar-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>create-jar</id>
@@ -148,7 +143,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.4</version>
+                <version>${maven-war-plugin.version}</version>
                 <configuration>
                     <!--  archiving the classes breaks the admin screen loads in course.java
                           the legacy lesson loader does not look in jar files for lessons  -->
@@ -168,7 +163,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.7</version>
+                <version>${build-helper-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-artifacts</id>
@@ -189,10 +184,10 @@
             <plugin>
                 <groupId>org.apache.tomcat.maven</groupId>
                 <artifactId>tomcat7-maven-plugin</artifactId>
-                <version>2.2</version>
+                <version>${tomcat7-maven-plugin.version}</version>
                 <configuration>
-                  <server>local_tomcat</server>
-                  <url>http://localhost:8080/manager</url>
+                    <server>local_tomcat</server>
+                    <url>http://localhost:8080/manager</url>
                     <path>/WebGoat</path>
                     <attachArtifactClassifier>exec</attachArtifactClassifier>
                     <contextReloadable>true</contextReloadable>
@@ -233,7 +228,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*IT.java</exclude>
@@ -252,52 +247,52 @@
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
-            <version>1.1</version>
+            <version>${activation.version}</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.187</version>
+            <version>${h2.version}</version>
         </dependency>
         <dependency>
             <groupId>axis</groupId>
             <artifactId>axis</artifactId>
-            <version>1.2</version>
+            <version>${axis.version}</version>
         </dependency>
         <dependency>
             <groupId>axis</groupId>
             <artifactId>axis-saaj</artifactId>
-            <version>1.2</version>
+            <version>${axis-saaj.version}</version>
         </dependency>
         <dependency>
             <groupId>axis</groupId>
             <artifactId>axis-jaxrpc</artifactId>
-            <version>1.2</version>
+            <version>${axis-jaxrpc.version}</version>
         </dependency>
         <dependency>
             <groupId>axis</groupId>
             <artifactId>axis-ant</artifactId>
-            <version>1.2</version>
+            <version>${axis-ant.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.1</version>
+            <version>${commons-collections.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-digester</groupId>
             <artifactId>commons-digester</artifactId>
-            <version>1.8.1</version>
+            <version>${commons-digester.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>xml-apis</groupId>
@@ -308,62 +303,62 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1.3</version>
+            <version>${commons-logging.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.7</version>
+            <version>${jcl-over-slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-discovery</groupId>
             <artifactId>commons-discovery</artifactId>
-            <version>0.2</version>
+            <version>${commons-discovery.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
-            <version>1.4.2</version>
+            <version>${mail.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mailapi</artifactId>
-            <version>1.4.2</version>
+            <version>${mail.version}</version>
         </dependency>
         <dependency>
             <groupId>hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>1.8.0.10</version>
+            <version>${hsqldb.version}</version>
         </dependency>
         <dependency>
             <groupId>wsdl4j</groupId>
             <artifactId>wsdl4j</artifactId>
-            <version>1.5.1</version>
+            <version>${wsdl4j.version}</version>
         </dependency>
         <dependency>
             <groupId>java2html</groupId>
             <artifactId>j2h</artifactId>
-            <version>1.3.1</version>
+            <version>${j2h.version}</version>
         </dependency>
         <dependency>
             <groupId>ecs</groupId>
             <artifactId>ecs</artifactId>
-            <version>1.4.2</version>
+            <version>${ecs.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
-            <version>1.2</version>
+            <version>${javax.transaction-api.version}</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>
             <artifactId>jtds</artifactId>
-            <version>1.2.2</version>
+            <version>${jtds.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>7.0.63</version>
+            <version>${tomcat-catalina.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -374,7 +369,7 @@
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
-            <version>6.0</version>
+            <version>${javaee-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -388,12 +383,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.0.4</version>
+            <version>${jackson-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.0.4</version>
+            <version>${jackson-databind.version}</version>
         </dependency>
 
         <!-- Spring MVC framework -->
@@ -426,32 +421,32 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2.2</version>
+            <version>${commons-fileupload.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>${guava.version}</version>
         </dependency>
 
         <!-- JSTL -->
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
-            <version>1.2</version>
+            <version>${jstl.version}</version>
         </dependency>
 
         <dependency>
             <groupId>taglibs</groupId>
             <artifactId>standard</artifactId>
-            <version>1.1.2</version>
+            <version>${standard.version}</version>
         </dependency>
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>${log4j.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.jms</groupId>
@@ -476,13 +471,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
+            <version>${slf4j-api.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.7</version>
+            <version>${slf4j-log4j12.version}</version>
             <type>jar</type>
         </dependency>
         <!-- ************* END spring MVC and related dependencies ************** -->
@@ -490,21 +485,22 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>2.47.1</version>
+            <version>${selenium-java.version}</version>
         </dependency>
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>sauce_junit</artifactId>
-            <version>2.1.18</version>
+            <version>${sauce_junit.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- ************* END: Dependencies for Unit and Integration Testing ************** -->
-    <!-- ************* END: <dependencies> ************** -->
+        <!-- ************* END: <dependencies> ************** -->
     </dependencies>
+
 </project>

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -68,7 +68,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>start-tomcat</id>
+                                <id>tomcat-startup</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>run-war-only</goal>
@@ -80,7 +80,7 @@
                             </execution>
                             <!-- At post-integration-test phase, stop the embedded Tomcat server. -->
                             <execution>
-                                <id>stop-tomcat</id>
+                                <id>tomcat-shutdown</id>
                                 <phase>post-integration-test</phase>
                                 <goals>
                                     <goal>shutdown</goal>

--- a/webgoat-container/src/main/java/org/owasp/webgoat/Catcher.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/Catcher.java
@@ -11,35 +11,37 @@ import org.owasp.webgoat.session.Course;
 import org.owasp.webgoat.session.WebSession;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created March 13, 2007
+ * @since March 13, 2007
+ * @version $Id: $Id
  */
 public class Catcher extends HammerHead
 {
@@ -54,19 +56,19 @@ public class Catcher extends HammerHead
 	 */
 	public final static String START_SOURCE_SKIP = "START_OMIT_SOURCE";
 
+	/** Constant <code>END_SOURCE_SKIP="END_OMIT_SOURCE"</code> */
 	public final static String END_SOURCE_SKIP = "END_OMIT_SOURCE";
 
+	/** Constant <code>PROPERTY="PROPERTY"</code> */
 	public static final String PROPERTY = "PROPERTY";
 
+	/** Constant <code>EMPTY_STRING=""</code> */
 	public static final String EMPTY_STRING = "";
 
 	/**
+	 * {@inheritDoc}
+	 *
 	 * Description of the Method
-	 * 
-	 * @param request
-	 *            Description of the Parameter
-	 * @param response
-	 *            Description of the Parameter
 	 * @exception IOException
 	 *                Description of the Exception
 	 * @exception ServletException

--- a/webgoat-container/src/main/java/org/owasp/webgoat/HammerHead.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/HammerHead.java
@@ -55,11 +55,11 @@ import java.util.TimeZone;
  *
  * For details, please see http://webgoat.github.io
  *
- *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect
  * Security</a>
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class HammerHead extends HttpServlet {
 
@@ -95,10 +95,9 @@ public class HammerHead extends HttpServlet {
     private WebgoatContext webgoatContext = null;
 
     /**
-     * Description of the Method
+     * {@inheritDoc}
      *
-     * @param request Description of the Parameter
-     * @param response Description of the Parameter
+     * Description of the Method
      * @exception IOException Description of the Exception
      * @exception ServletException Description of the Exception
      */
@@ -108,10 +107,9 @@ public class HammerHead extends HttpServlet {
     }
 
     /**
-     * Description of the Method
+     * {@inheritDoc}
      *
-     * @param request Description of the Parameter
-     * @param response Description of the Parameter
+     * Description of the Method
      * @exception IOException Description of the Exception
      * @exception ServletException Description of the Exception
      */
@@ -227,9 +225,9 @@ public class HammerHead extends HttpServlet {
     }
 
     /**
-     * Return information about this servlet
+     * {@inheritDoc}
      *
-     * @return The servletInfo value
+     * Return information about this servlet
      */
     @Override
     public String getServletInfo() {
@@ -237,9 +235,9 @@ public class HammerHead extends HttpServlet {
     }
 
     /**
-     * Return properties path
+     * {@inheritDoc}
      *
-     * @throws javax.servlet.ServletException
+     * Return properties path
      */
     @Override
     public void init() throws ServletException {
@@ -371,7 +369,7 @@ public class HammerHead extends HttpServlet {
      * @param response Description of the Parameter
      * @param context Description of the Parameter
      * @return Description of the Return Value
-     * @throws java.io.IOException
+     * @throws java.io.IOException if any.
      */
     protected WebSession updateSession(HttpServletRequest request, HttpServletResponse response, ServletContext context)
             throws IOException {
@@ -415,9 +413,10 @@ public class HammerHead extends HttpServlet {
      * Description of the Method
      *
      * @param s Description of the Parameter
-     * @param screen
+     * @param screen a {@link org.owasp.webgoat.session.Screen} object.
      * @param response Description of the Parameter
      * @exception IOException Description of the Exception
+     * @throws java.io.IOException if any.
      */
     protected void writeScreen(WebSession s, Screen screen, HttpServletResponse response) throws IOException {
         response.setContentType("text/html");

--- a/webgoat-container/src/main/java/org/owasp/webgoat/LessonSource.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/LessonSource.java
@@ -40,7 +40,8 @@ import org.owasp.webgoat.session.WebSession;
  * For details, please see http://webgoat.github.io
  *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class LessonSource extends HammerHead {
 
@@ -54,13 +55,13 @@ public class LessonSource extends HammerHead {
      */
     public final static String START_SOURCE_SKIP = "START_OMIT_SOURCE";
 
+    /** Constant <code>END_SOURCE_SKIP="END_OMIT_SOURCE"</code> */
     public final static String END_SOURCE_SKIP = "END_OMIT_SOURCE";
 
     /**
-     * Description of the Method
+     * {@inheritDoc}
      *
-     * @param request Description of the Parameter
-     * @param response Description of the Parameter
+     * Description of the Method
      * @exception IOException Description of the Exception
      * @exception ServletException Description of the Exception
      */
@@ -142,6 +143,12 @@ public class LessonSource extends HammerHead {
                 "Code Section Deliberately Omitted"));
     }
 
+    /**
+     * <p>getSolution.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     protected String getSolution(WebSession s) {
 
         String source = null;
@@ -169,6 +176,7 @@ public class LessonSource extends HammerHead {
      * @param s Description of the Parameter
      * @param response Description of the Parameter
      * @exception IOException Description of the Exception
+     * @throws java.io.IOException if any.
      */
     protected void writeSource(String s, HttpServletResponse response) throws IOException {
         response.setContentType("text/html");

--- a/webgoat-container/src/main/java/org/owasp/webgoat/application/Application.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/application/Application.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * Singleton which is created on context startup
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public class Application {
 
@@ -21,6 +22,11 @@ public class Application {
 
     }
 
+    /**
+     * <p>getInstance.</p>
+     *
+     * @return a {@link org.owasp.webgoat.application.Application} object.
+     */
     public static final Application getInstance() {
         return INSTANCE;
     }
@@ -30,6 +36,8 @@ public class Application {
     private String name = "WebGoat";
 
     /**
+     * <p>Getter for the field <code>version</code>.</p>
+     *
      * @return the version
      */
     public String getVersion() {
@@ -37,6 +45,8 @@ public class Application {
     }
 
     /**
+     * <p>Setter for the field <code>version</code>.</p>
+     *
      * @param version the version to set
      */
     public void setVersion(String version) {
@@ -46,6 +56,8 @@ public class Application {
     }
 
     /**
+     * <p>Getter for the field <code>build</code>.</p>
+     *
      * @return the build
      */
     public String getBuild() {
@@ -53,6 +65,8 @@ public class Application {
     }
 
     /**
+     * <p>Setter for the field <code>build</code>.</p>
+     *
      * @param build the build to set
      */
     public void setBuild(String build) {
@@ -62,6 +76,8 @@ public class Application {
     }
 
     /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
      * @return the name
      */
     public String getName() {
@@ -69,6 +85,8 @@ public class Application {
     }
 
     /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
      * @param name the name to set
      */
     public void setName(String name) {
@@ -77,6 +95,7 @@ public class Application {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return new ToStringBuilder(this).

--- a/webgoat-container/src/main/java/org/owasp/webgoat/application/WebGoatServletListener.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/application/WebGoatServletListener.java
@@ -17,9 +17,11 @@ import java.util.jar.Manifest;
  * Web application lifecycle listener.
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public class WebGoatServletListener implements ServletContextListener {
 
+    /** {@inheritDoc} */
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         ServletContext context = sce.getServletContext();
@@ -27,6 +29,7 @@ public class WebGoatServletListener implements ServletContextListener {
         setApplicationVariables(context);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
         ServletContext context = sce.getServletContext();

--- a/webgoat-container/src/main/java/org/owasp/webgoat/controller/About.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/controller/About.java
@@ -16,8 +16,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
+ * <p>About class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class About {
@@ -25,6 +27,14 @@ public class About {
     final Logger logger = LoggerFactory.getLogger(About.class);
     private static final String WELCOMED = "welcomed";
     
+    /**
+     * <p>welcome.</p>
+     *
+     * @param request a {@link javax.servlet.http.HttpServletRequest} object.
+     * @param error a {@link java.lang.String} object.
+     * @param logout a {@link java.lang.String} object.
+     * @return a {@link org.springframework.web.servlet.ModelAndView} object.
+     */
     @RequestMapping(value = "about.mvc", method = RequestMethod.GET)
     public ModelAndView welcome(HttpServletRequest request,
             @RequestParam(value = "error", required = false) String error,

--- a/webgoat-container/src/main/java/org/owasp/webgoat/controller/Login.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/controller/Login.java
@@ -12,12 +12,21 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
+ * <p>Login class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class Login {
 
+    /**
+     * <p>login.</p>
+     *
+     * @param error a {@link java.lang.String} object.
+     * @param logout a {@link java.lang.String} object.
+     * @return a {@link org.springframework.web.servlet.ModelAndView} object.
+     */
     @RequestMapping(value = "login.mvc", method = RequestMethod.GET)
     public ModelAndView login(
             @RequestParam(value = "error", required = false) String error,

--- a/webgoat-container/src/main/java/org/owasp/webgoat/controller/Logout.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/controller/Logout.java
@@ -14,14 +14,23 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
+ * <p>Logout class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class Logout {
 
     final Logger logger = LoggerFactory.getLogger(Logout.class);
 
+    /**
+     * <p>logout.</p>
+     *
+     * @param error a {@link java.lang.String} object.
+     * @param logout a {@link java.lang.String} object.
+     * @return a {@link org.springframework.web.servlet.ModelAndView} object.
+     */
     @RequestMapping(value = "logout.mvc", method = RequestMethod.GET)
     public ModelAndView logout(
             @RequestParam(value = "error", required = false) String error,

--- a/webgoat-container/src/main/java/org/owasp/webgoat/controller/Start.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/controller/Start.java
@@ -24,8 +24,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
+ * <p>Start class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class Start {
@@ -37,6 +39,14 @@ public class Start {
     @Autowired
     private ServletContext servletContext;
 
+    /**
+     * <p>start.</p>
+     *
+     * @param request a {@link javax.servlet.http.HttpServletRequest} object.
+     * @param error a {@link java.lang.String} object.
+     * @param logout a {@link java.lang.String} object.
+     * @return a {@link org.springframework.web.servlet.ModelAndView} object.
+     */
     @RequestMapping(value = "start.mvc", method = {RequestMethod.GET, RequestMethod.POST})
     public ModelAndView start(HttpServletRequest request,
             @RequestParam(value = "error", required = false) String error,
@@ -82,6 +92,12 @@ public class Start {
         return role;
     }
 
+    /**
+     * <p>checkWebSession.</p>
+     *
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a boolean.
+     */
     public boolean checkWebSession(HttpSession session) {
         Object o = session.getAttribute(WebSession.SESSION);
         if (o == null) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/controller/Welcome.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/controller/Welcome.java
@@ -16,8 +16,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
+ * <p>Welcome class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class Welcome {
@@ -25,6 +27,14 @@ public class Welcome {
     final Logger logger = LoggerFactory.getLogger(Welcome.class);
     private static final String WELCOMED = "welcomed";
     
+    /**
+     * <p>welcome.</p>
+     *
+     * @param request a {@link javax.servlet.http.HttpServletRequest} object.
+     * @param error a {@link java.lang.String} object.
+     * @param logout a {@link java.lang.String} object.
+     * @return a {@link org.springframework.web.servlet.ModelAndView} object.
+     */
     @RequestMapping(value = "welcome.mvc", method = RequestMethod.GET)
     public ModelAndView welcome(HttpServletRequest request,
             @RequestParam(value = "error", required = false) String error,

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/AbstractLesson.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/AbstractLesson.java
@@ -37,37 +37,36 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * *************************************************************************************************
- * <p>
- * <p>
- * This file is part of WebGoat, an Open Web Application Security Project
- * utility. For details, please see http://www.owasp.org/
- * <p>
+ *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * <p>
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * <p>
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- * <p>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
  * Getting Source ==============
- * <p>
- * Source for this application is maintained at
- * https://github.com/WebGoat/WebGoat, a repository for free software projects.
- * <p>
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ *
  * For details, please see http://webgoat.github.io
  *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public abstract class AbstractLesson extends Screen implements Comparable<Object> {
 
@@ -78,6 +77,7 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
      */
     public final static String ADMIN_ROLE = "admin";
 
+    /** Constant <code>CHALLENGE_ROLE="challenge"</code> */
     public final static String CHALLENGE_ROLE = "challenge";
 
     /**
@@ -126,19 +126,39 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         id = new Integer(++count);
     }
 
+    /**
+     * <p>getName.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         String className = getClass().getName();
         return className.substring(className.lastIndexOf('.') + 1);
     }
 
+    /**
+     * <p>Setter for the field <code>ranking</code>.</p>
+     *
+     * @param ranking a {@link java.lang.Integer} object.
+     */
     public void setRanking(Integer ranking) {
         this.ranking = ranking;
     }
 
+    /**
+     * <p>Setter for the field <code>hidden</code>.</p>
+     *
+     * @param hidden a boolean.
+     */
     public void setHidden(boolean hidden) {
         this.hidden = hidden;
     }
 
+    /**
+     * <p>update.</p>
+     *
+     * @param properties a {@link org.owasp.webgoat.session.WebgoatProperties} object.
+     */
     public void update(WebgoatProperties properties) {
         String className = getClass().getName();
         className = className.substring(className.lastIndexOf(".") + 1);
@@ -156,6 +176,12 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         // " + getRanking() + ", hidden:" + hidden +")");
     }
 
+    /**
+     * <p>isCompleted.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a boolean.
+     */
     public boolean isCompleted(WebSession s) {
         return getLessonTracker(s, this).getCompleted();
     }
@@ -169,20 +195,18 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     public abstract Element getCredits();
 
     /**
-     * Description of the Method
+     * {@inheritDoc}
      *
-     * @param obj Description of the Parameter
-     * @return Description of the Return Value
+     * Description of the Method
      */
     public int compareTo(Object obj) {
         return this.getRanking().compareTo(((AbstractLesson) obj).getRanking());
     }
 
     /**
-     * Description of the Method
+     * {@inheritDoc}
      *
-     * @param obj Description of the Parameter
-     * @return Description of the Return Value
+     * Description of the Method
      */
     public boolean equals(Object obj) {
         return this.getScreenId() == ((AbstractLesson) obj).getScreenId();
@@ -197,10 +221,25 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return category;
     }
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected abstract Integer getDefaultRanking();
 
+    /**
+     * <p>getDefaultCategory.</p>
+     *
+     * @return a {@link org.owasp.webgoat.lessons.Category} object.
+     */
     protected abstract Category getDefaultCategory();
 
+    /**
+     * <p>getDefaultHidden.</p>
+     *
+     * @return a boolean.
+     */
     protected abstract boolean getDefaultHidden();
 
     /**
@@ -322,10 +361,22 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return getHints(s).size();
     }
 
+    /**
+     * <p>getHints.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.util.List} object.
+     */
     protected abstract List<String> getHints(WebSession s);
 
     // @TODO we need to restrict access at the service layer
     // rather than passing session object around
+    /**
+     * <p>getHintsPublic.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.util.List} object.
+     */
     public List<String> getHintsPublic(WebSession s) {
         List<String> hints = getHints(s);
         return hints;
@@ -337,6 +388,7 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
      *
      * @param s The users WebSession
      * @return The hint1 value
+     * @param hintNumber a int.
      */
     public String getHint(WebSession s, int hintNumber) {
         return "Hint: " + getHints(s).get(hintNumber);
@@ -346,6 +398,7 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
      * Gets the instructions attribute of the AbstractLesson object
      *
      * @return The instructions value
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
      */
     public abstract String getInstructions(WebSession s);
 
@@ -444,6 +497,12 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return id.intValue();
     }
 
+    /**
+     * <p>getHtml_DELETE_ME.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String getHtml_DELETE_ME(WebSession s) {
         String html = null;
 
@@ -459,6 +518,12 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return html;
     }
 
+    /**
+     * <p>getSource.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String getSource(WebSession s) {
         String source = null;
         String src = null;
@@ -498,6 +563,12 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return source;
     }
 
+    /**
+     * <p>getRawSource.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String getRawSource(WebSession s) {
         String src;
 
@@ -517,6 +588,12 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return src;
     }
 
+    /**
+     * <p>getSolution.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String getSolution(WebSession s) {
         String src = null;
 
@@ -538,17 +615,17 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     }
 
     /**
-     * <p>
-     * Returns the default "path" portion of a lesson's URL.</p>
-     * <p>
-     * <p>
+     * <p>Returns the default "path" portion of a lesson's URL.</p>
+     *
+     *
      * Legacy webgoat lesson links are of the form
      * "attack?Screen=Xmenu=Ystage=Z". This method returns the path portion of
-     * the url, i.e., "attack" in the string above.</p>
-     * <p>
-     * <p>
+     * the url, i.e., "attack" in the string above.
+     *
      * Newer, Spring-Controller-based classes will override this method to
-     * return "*.do"-styled paths.</p>
+     * return "*.do"-styled paths.
+     *
+     * @return a {@link java.lang.String} object.
      */
     protected String getPath() {
         return "#attack";
@@ -557,7 +634,7 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     /**
      * Get the link that can be used to request this screen.
      *
-     * @return
+     * @return a {@link java.lang.String} object.
      */
     public String getLink() {
         StringBuffer link = new StringBuffer();
@@ -574,7 +651,8 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     /**
      * Get the link to the jsp page used to render this screen.
      *
-     * @return
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
      */
     public String getPage(WebSession s) {
         return null;
@@ -583,22 +661,36 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     /**
      * Get the link to the jsp template page used to render this screen.
      *
-     * @return
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
      */
     public String getTemplatePage(WebSession s) {
         return null;
     }
 
+    /**
+     * <p>getCurrentAction.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     public abstract String getCurrentAction(WebSession s);
 
+    /**
+     * <p>setCurrentAction.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param lessonScreen a {@link java.lang.String} object.
+     */
     public abstract void setCurrentAction(WebSession s, String lessonScreen);
 
     /**
      * Override this method to implement accesss control in a lesson.
      *
-     * @param s
-     * @param functionId
-     * @return
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param functionId a {@link java.lang.String} object.
+     * @param employeeId a int.
+     * @return a boolean.
      */
     public boolean isAuthorized(WebSession s, int employeeId, String functionId) {
         return false;
@@ -607,9 +699,10 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     /**
      * Override this method to implement accesss control in a lesson.
      *
-     * @param s
-     * @param functionId
-     * @return
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param functionId a {@link java.lang.String} object.
+     * @param role a {@link java.lang.String} object.
+     * @return a boolean.
      */
     public boolean isAuthorized(WebSession s, String role, String functionId) {
         logger.info("Checking if " + role + " authorized for: " + functionId);
@@ -633,10 +726,24 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return authorized;
     }
 
+    /**
+     * <p>getUserId.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a int.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     */
     public int getUserId(WebSession s) throws ParameterNotFoundException {
         return -1;
     }
 
+    /**
+     * <p>getUserName.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     */
     public String getUserName(WebSession s) throws ParameterNotFoundException {
         return null;
     }
@@ -739,6 +846,11 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         s.getRequest().getRequestURL();
     }
 
+    /**
+     * <p>getFormAction.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getFormAction() {
         return getLink();
     }
@@ -746,17 +858,27 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     /**
      * Description of the Method
      *
-     * @param s Description of the Parameter
      * @return Description of the Return Value
      */
     public String toString() {
         return getTitle();
     }
 
+    /**
+     * <p>Getter for the field <code>defaultLanguage</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDefaultLanguage() {
         return this.defaultLanguage;
     }
 
+    /**
+     * <p>Getter for the field <code>lessonPlanFileName</code>.</p>
+     *
+     * @param lang a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String getLessonPlanFileName(String lang) {
         String ret = lessonPlanFileName.get(lang);
         if (ret == null) {
@@ -765,40 +887,86 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
         return ret;
     }
 
+    /**
+     * <p>Setter for the field <code>lessonPlanFileName</code>.</p>
+     *
+     * @param lang a {@link java.lang.String} object.
+     * @param lessonPlanFileName a {@link java.lang.String} object.
+     */
     public void setLessonPlanFileName(String lang, String lessonPlanFileName) {
         this.lessonPlanFileName.put(lang, lessonPlanFileName);
         this.availableLanguages.add(lang);
     }
 
+    /**
+     * <p>Getter for the field <code>availableLanguages</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<String> getAvailableLanguages() {
         return this.availableLanguages;
     }
 
+    /**
+     * <p>Getter for the field <code>lessonSolutionFileName</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getLessonSolutionFileName() {
         return lessonSolutionFileName;
     }
 
+    /**
+     * <p>Setter for the field <code>lessonSolutionFileName</code>.</p>
+     *
+     * @param lessonSolutionFileName a {@link java.lang.String} object.
+     */
     public void setLessonSolutionFileName(String lessonSolutionFileName) {
         this.lessonSolutionFileName = lessonSolutionFileName;
     }
 
+    /**
+     * <p>Getter for the field <code>sourceFileName</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getSourceFileName() {
         return sourceFileName;
     }
 
+    /**
+     * <p>Setter for the field <code>sourceFileName</code>.</p>
+     *
+     * @param sourceFileName a {@link java.lang.String} object.
+     */
     public void setSourceFileName(String sourceFileName) {
         logger.debug("Setting source file of lesson " + this + " to: " + sourceFileName);
         this.sourceFileName = sourceFileName;
     }
 
+    /**
+     * <p>Getter for the field <code>webgoatContext</code>.</p>
+     *
+     * @return a {@link org.owasp.webgoat.session.WebgoatContext} object.
+     */
     public WebgoatContext getWebgoatContext() {
         return webgoatContext;
     }
 
+    /**
+     * <p>Setter for the field <code>webgoatContext</code>.</p>
+     *
+     * @param webgoatContext a {@link org.owasp.webgoat.session.WebgoatContext} object.
+     */
     public void setWebgoatContext(WebgoatContext webgoatContext) {
         this.webgoatContext = webgoatContext;
     }
 
+    /**
+     * <p>Getter for the field <code>labelManager</code>.</p>
+     *
+     * @return a {@link org.owasp.webgoat.util.LabelManager} object.
+     */
     protected LabelManager getLabelManager() {
         if (labelManager == null) {
             labelManager = BeanProvider.getBean("labelManager", LabelManager.class);
@@ -812,6 +980,10 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
      * A reference in include directives are made from within the web application on the server.
      * However, img tags (and the like) make references from the client browser.
      * In such external references, the context path must be included.
+     *
+     * @param w a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param imgResourceName a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
      */
     protected final String buildImagePath(WebSession w, String imgResourceName) {
         return w.getRequest()
@@ -819,16 +991,37 @@ public abstract class AbstractLesson extends Screen implements Comparable<Object
     }
 
 
+    /**
+     * <p>buildJspPath.</p>
+     *
+     * @param w a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param jspResourceName a {@link java.lang.String} object.
+     * @param includeContextPath a boolean.
+     * @return a {@link java.lang.String} object.
+     */
     protected final String buildJspPath(WebSession w, String jspResourceName, boolean includeContextPath) {
         String path = includeContextPath ? w.getContext().getContextPath() : "";
         return path + "/plugin_extracted/plugin/" + getLessonName() + "/jsp/" + jspResourceName;
     }
 
+    /**
+     * <p>buildJsPath.</p>
+     *
+     * @param w a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param jsResourceName a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
     protected final String buildJsPath(WebSession w, String jsResourceName) {
         return w.getRequest()
                 .getContextPath() + "/plugin_extracted/plugin/" + getLessonName() + "/js/" + jsResourceName;
     }
 
+    /**
+     * <p>getLessonDirectory.</p>
+     *
+     * @param w a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.io.File} object.
+     */
     protected final File getLessonDirectory(WebSession w) {
         return new File(w.getContext().getRealPath("/plugin_extracted/plugin/" + getLessonName() + "/"));
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Category.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Category.java
@@ -35,50 +35,72 @@ import java.util.List;
  * For details, please see http://webgoat.github.io
  *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class Category implements Comparable {
 
+    /** Constant <code>INTRODUCTION</code> */
     public final static Category INTRODUCTION = new Category("Introduction", new Integer(5));
 
+    /** Constant <code>GENERAL</code> */
     public final static Category GENERAL = new Category("General", new Integer(100));
 
+    /** Constant <code>ACCESS_CONTROL</code> */
     public final static Category ACCESS_CONTROL = new Category("Access Control Flaws", new Integer(200));
 
+    /** Constant <code>AJAX_SECURITY</code> */
     public final static Category AJAX_SECURITY = new Category("AJAX Security", new Integer(400));
 
+    /** Constant <code>AUTHENTICATION</code> */
     public final static Category AUTHENTICATION = new Category("Authentication Flaws", new Integer(500));
 
+    /** Constant <code>BUFFER_OVERFLOW</code> */
     public final static Category BUFFER_OVERFLOW = new Category("Buffer Overflows", new Integer(600));
 
+    /** Constant <code>CODE_QUALITY</code> */
     public final static Category CODE_QUALITY = new Category("Code Quality", new Integer(700));
 
+    /** Constant <code>CONCURRENCY</code> */
     public final static Category CONCURRENCY = new Category("Concurrency", new Integer(800));
 
+    /** Constant <code>XSS</code> */
     public final static Category XSS = new Category("Cross-Site Scripting (XSS)", new Integer(900));
 
+    /** Constant <code>ERROR_HANDLING</code> */
     public final static Category ERROR_HANDLING = new Category("Improper Error Handling", new Integer(1000));
 
+    /** Constant <code>INJECTION</code> */
     public final static Category INJECTION = new Category("Injection Flaws", new Integer(1100));
 
+    /** Constant <code>DOS</code> */
     public final static Category DOS = new Category("Denial of Service", new Integer(1200));
 
+    /** Constant <code>INSECURE_COMMUNICATION</code> */
     public final static Category INSECURE_COMMUNICATION = new Category("Insecure Communication", new Integer(1300));
 
+    /** Constant <code>INSECURE_CONFIGURATION</code> */
     public final static Category INSECURE_CONFIGURATION = new Category("Insecure Configuration", new Integer(1400));
 
+    /** Constant <code>INSECURE_STORAGE</code> */
     public final static Category INSECURE_STORAGE = new Category("Insecure Storage", new Integer(1500));
 
+    /** Constant <code>MALICIOUS_EXECUTION</code> */
     public final static Category MALICIOUS_EXECUTION = new Category("Malicious Execution", new Integer(1600));
 
+    /** Constant <code>PARAMETER_TAMPERING</code> */
     public final static Category PARAMETER_TAMPERING = new Category("Parameter Tampering", new Integer(1700));
 
+    /** Constant <code>SESSION_MANAGEMENT</code> */
     public final static Category SESSION_MANAGEMENT = new Category("Session Management Flaws", new Integer(1800));
 
+    /** Constant <code>WEB_SERVICES</code> */
     public final static Category WEB_SERVICES = new Category("Web Services", new Integer(1900));
 
+    /** Constant <code>ADMIN_FUNCTIONS</code> */
     public final static Category ADMIN_FUNCTIONS = new Category("Admin Functions", new Integer(2000));
 
+    /** Constant <code>CHALLENGE</code> */
     public final static Category CHALLENGE = new Category("Challenge", new Integer(3000));
 
     private static final List<Category> categories = new ArrayList<Category>();
@@ -111,10 +133,21 @@ public class Category implements Comparable {
         categories.add(CHALLENGE);
     }
 
+    /**
+     * <p>addCategory.</p>
+     *
+     * @param c a {@link org.owasp.webgoat.lessons.Category} object.
+     */
     public static synchronized void addCategory(Category c) {
         categories.add(c);
     }
 
+    /**
+     * <p>Getter for the field <code>category</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link org.owasp.webgoat.lessons.Category} object.
+     */
     public static synchronized Category getCategory(String name) {
         Iterator<Category> it = categories.iterator();
         while (it.hasNext()) {
@@ -126,11 +159,18 @@ public class Category implements Comparable {
         return null;
     }
 
+    /**
+     * <p>Constructor for Category.</p>
+     *
+     * @param category a {@link java.lang.String} object.
+     * @param ranking a {@link java.lang.Integer} object.
+     */
     public Category(String category, Integer ranking) {
         this.category = category;
         this.ranking = ranking;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int compareTo(Object obj) {
         int value = 1;
@@ -142,23 +182,41 @@ public class Category implements Comparable {
         return value;
     }
 
+    /**
+     * <p>Getter for the field <code>ranking</code>.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     public Integer getRanking() {
         return ranking;
     }
 
+    /**
+     * <p>Setter for the field <code>ranking</code>.</p>
+     *
+     * @param ranking a {@link java.lang.Integer} object.
+     * @return a {@link java.lang.Integer} object.
+     */
     public Integer setRanking(Integer ranking) {
         return this.ranking = ranking;
     }
 
+    /**
+     * <p>getName.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return category;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         return (obj instanceof Category) && getName().equals(((Category) obj).getName());
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return getName();

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/LessonAdapter.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/LessonAdapter.java
@@ -22,45 +22,43 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * *************************************************************************************************
- * <p>
- * <p>
- * This file is part of WebGoat, an Open Web Application Security Project
- * utility. For details, please see http://www.owasp.org/
- * <p>
+ *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * <p>
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * <p>
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- * <p>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
  * Getting Source ==============
- * <p>
- * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
- * for free software projects.
- * <p>
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ *
  * For details, please see http://webgoat.github.io
  *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public abstract class LessonAdapter extends AbstractLesson {
 
     /**
-     * Description of the Method
+     * {@inheritDoc}
      *
-     * @param s Description of the Parameter
-     * @return Description of the Return Value
+     * Description of the Method
      */
     protected Element createContent(WebSession s) {
         // Mark this lesson as completed.
@@ -104,32 +102,42 @@ public abstract class LessonAdapter extends AbstractLesson {
         return Category.GENERAL;
     }
 
+    /**
+     * <p>getDefaultHidden.</p>
+     *
+     * @return a boolean.
+     */
     protected boolean getDefaultHidden() {
         return false;
     }
 
     private final static Integer DEFAULT_RANKING = new Integer(1000);
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected Integer getDefaultRanking() {
         return DEFAULT_RANKING;
     }
 
     /**
-     * Gets the hintCount attribute of the LessonAdapter object
+     * {@inheritDoc}
      *
-     * @return The hintCount value
+     * Gets the hintCount attribute of the LessonAdapter object
      */
     public int getHintCount(WebSession s) {
         return getHints(s).size();
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Fill in a minor hint that will help people who basically get it, but are
      * stuck on somthing silly. Hints will be returned to the user in the order
      * they appear below. The user must click on the "next hint" button before
      * the hint will be displayed.
-     *
-     * @return The hint1 value
      */
     protected List<String> getHints(WebSession s) {
         List<String> hints = new ArrayList<String>();
@@ -149,12 +157,12 @@ public abstract class LessonAdapter extends AbstractLesson {
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Gets the instructions attribute of the LessonAdapter object. Instructions
      * will rendered as html and will appear below the control area and above
      * the actual lesson area. Instructions should provide the user with the
      * general setup and goal of the lesson.
-     *
-     * @return The instructions value
      */
     public String getInstructions(WebSession s) {
         StringBuffer buff = new StringBuffer();
@@ -197,18 +205,34 @@ public abstract class LessonAdapter extends AbstractLesson {
         return "Untitled Lesson " + getScreenId();
     }
 
+    /** {@inheritDoc} */
     public String getCurrentAction(WebSession s) {
         return s.getLessonSession(this).getCurrentLessonScreen();
     }
 
+    /** {@inheritDoc} */
     public void setCurrentAction(WebSession s, String lessonScreen) {
         s.getLessonSession(this).setCurrentLessonScreen(lessonScreen);
     }
 
+    /**
+     * <p>getSessionAttribute.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param key a {@link java.lang.String} object.
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getSessionAttribute(WebSession s, String key) {
         return s.getRequest().getSession().getAttribute(key);
     }
 
+    /**
+     * <p>setSessionAttribute.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param key a {@link java.lang.String} object.
+     * @param value a {@link java.lang.Object} object.
+     */
     public void setSessionAttribute(WebSession s, String key, Object value) {
         s.getRequest().getSession().setAttribute(key, value);
     }
@@ -231,6 +255,8 @@ public abstract class LessonAdapter extends AbstractLesson {
      * Gets the credits attribute of the AbstractLesson object
      *
      * @return The credits value
+     * @param text a {@link java.lang.String} object.
+     * @param e a {@link org.apache.ecs.Element} object.
      */
     protected Element getCustomCredits(String text, Element e) {
         Table t = new Table().setCellSpacing(0).setCellPadding(0).setBorder(0).setWidth("90%").setAlign("RIGHT");

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/RandomLessonAdapter.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/RandomLessonAdapter.java
@@ -10,11 +10,27 @@ import org.owasp.webgoat.session.RandomLessonTracker;
 import org.owasp.webgoat.session.WebSession;
 
 
+/**
+ * <p>Abstract RandomLessonAdapter class.</p>
+ *
+ * @version $Id: $Id
+ */
 public abstract class RandomLessonAdapter extends LessonAdapter
 {
 
+    /**
+     * <p>getStages.</p>
+     *
+     * @return an array of {@link java.lang.String} objects.
+     */
     public abstract String[] getStages();
 
+    /**
+     * <p>setStage.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param stage a {@link java.lang.String} object.
+     */
     public void setStage(WebSession s, String stage)
     {
         getLessonTracker(s).setStage(stage);
@@ -33,11 +49,23 @@ public abstract class RandomLessonAdapter extends LessonAdapter
         }
     }
 
+    /**
+     * <p>getStage.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String getStage(WebSession s)
     {
         return getLessonTracker(s).getStage();
     }
 
+    /**
+     * <p>setStageComplete.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param stage a {@link java.lang.String} object.
+     */
     public void setStageComplete(WebSession s, String stage)
     {
         RandomLessonTracker lt = getLessonTracker(s);
@@ -67,29 +95,40 @@ public abstract class RandomLessonAdapter extends LessonAdapter
         }
     }
 
+    /**
+     * <p>isStageComplete.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param stage a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public boolean isStageComplete(WebSession s, String stage)
     {
         return getLessonTracker(s).hasCompleted(stage);
     }
 
+    /** {@inheritDoc} */
     @Override
     public RandomLessonTracker getLessonTracker(WebSession s)
     {
         return (RandomLessonTracker) super.getLessonTracker(s);
     }
 
+    /** {@inheritDoc} */
     @Override
     public RandomLessonTracker getLessonTracker(WebSession s, AbstractLesson lesson)
     {
         return (RandomLessonTracker) super.getLessonTracker(s, lesson);
     }
 
+    /** {@inheritDoc} */
     @Override
     public RandomLessonTracker getLessonTracker(WebSession s, String userNameOverride)
     {
         return (RandomLessonTracker) super.getLessonTracker(s, userNameOverride);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LessonTracker createLessonTracker()
     {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/SequentialLessonAdapter.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/SequentialLessonAdapter.java
@@ -9,9 +9,20 @@ import org.owasp.webgoat.session.SequentialLessonTracker;
 import org.owasp.webgoat.session.WebSession;
 
 
+/**
+ * <p>Abstract SequentialLessonAdapter class.</p>
+ *
+ * @version $Id: $Id
+ */
 public abstract class SequentialLessonAdapter extends LessonAdapter
 {
 
+    /**
+     * <p>setStage.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param stage a int.
+     */
     public void setStage(WebSession s, int stage)
     {
         // System.out.println("Changed to stage " + stage);
@@ -21,11 +32,22 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
     /*
      * By default returns 1 stage. (non-Javadoc)
      */
+    /**
+     * <p>getStageCount.</p>
+     *
+     * @return a int.
+     */
     public int getStageCount()
     {
         return 1;
     }
 
+    /**
+     * <p>getStage.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a int.
+     */
     public int getStage(WebSession s)
     {
         int stage = getLessonTracker(s).getStage();
@@ -34,30 +56,40 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
         return stage;
     }
 
+    /** {@inheritDoc} */
     @Override
     public SequentialLessonTracker getLessonTracker(WebSession s)
     {
         return (SequentialLessonTracker) super.getLessonTracker(s);
     }
 
+    /** {@inheritDoc} */
     @Override
     public SequentialLessonTracker getLessonTracker(WebSession s, AbstractLesson lesson)
     {
         return (SequentialLessonTracker) super.getLessonTracker(s, lesson);
     }
 
+    /** {@inheritDoc} */
     @Override
     public SequentialLessonTracker getLessonTracker(WebSession s, String userNameOverride)
     {
         return (SequentialLessonTracker) super.getLessonTracker(s, userNameOverride);
     }
 
+    /** {@inheritDoc} */
     @Override
     public LessonTracker createLessonTracker()
     {
         return new SequentialLessonTracker();
     }
 
+    /**
+     * <p>createStagedContent.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     */
     protected Element createStagedContent(WebSession s)
     {
         try
@@ -93,6 +125,13 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
         return (new StringElement(""));
     }
 
+    /**
+     * <p>doStage1.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     * @throws java.lang.Exception if any.
+     */
     protected Element doStage1(WebSession s) throws Exception
     {
         ElementContainer ec = new ElementContainer();
@@ -100,6 +139,13 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
         return ec;
     }
 
+    /**
+     * <p>doStage2.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     * @throws java.lang.Exception if any.
+     */
     protected Element doStage2(WebSession s) throws Exception
     {
         ElementContainer ec = new ElementContainer();
@@ -107,6 +153,13 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
         return ec;
     }
 
+    /**
+     * <p>doStage3.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     * @throws java.lang.Exception if any.
+     */
     protected Element doStage3(WebSession s) throws Exception
     {
         ElementContainer ec = new ElementContainer();
@@ -114,6 +167,13 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
         return ec;
     }
 
+    /**
+     * <p>doStage4.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     * @throws java.lang.Exception if any.
+     */
     protected Element doStage4(WebSession s) throws Exception
     {
         ElementContainer ec = new ElementContainer();
@@ -121,6 +181,13 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
         return ec;
     }
 
+    /**
+     * <p>doStage5.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     * @throws java.lang.Exception if any.
+     */
     protected Element doStage5(WebSession s) throws Exception
     {
         ElementContainer ec = new ElementContainer();
@@ -128,6 +195,13 @@ public abstract class SequentialLessonAdapter extends LessonAdapter
         return ec;
     }
 
+    /**
+     * <p>doStage6.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     * @throws java.lang.Exception if any.
+     */
     protected Element doStage6(WebSession s) throws Exception
     {
         ElementContainer ec = new ElementContainer();

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/WelcomeScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/WelcomeScreen.java
@@ -13,42 +13,44 @@ import org.apache.ecs.html.Table;
 import org.owasp.webgoat.session.*;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class WelcomeScreen extends Screen
 {
 
     /**
      * Constructor for the WelcomeScreen object
-     * 
+     *
      * @param s
      *            Description of the Parameter
      */
@@ -64,6 +66,11 @@ public class WelcomeScreen extends Screen
     {
     }
 
+    /**
+     * <p>setup.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     */
     public void setup(WebSession s)
     {
         // call createContent first so messages will go somewhere
@@ -81,6 +88,12 @@ public class WelcomeScreen extends Screen
         setContent(layout);
     }
 
+    /**
+     * <p>wrapForm.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     */
     protected Element wrapForm(WebSession s)
     {
         if (s == null) { return new StringElement("Invalid Session"); }
@@ -97,11 +110,9 @@ public class WelcomeScreen extends Screen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -114,7 +125,7 @@ public class WelcomeScreen extends Screen
 
     /**
      * Gets the instructions attribute of the WelcomeScreen object
-     * 
+     *
      * @return The instructions value
      */
     protected String getInstructions()
@@ -126,7 +137,7 @@ public class WelcomeScreen extends Screen
 
     /**
      * Gets the title attribute of the WelcomeScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()
@@ -137,6 +148,11 @@ public class WelcomeScreen extends Screen
     /*
      * (non-Javadoc)
      * @see session.Screen#getRole()
+     */
+    /**
+     * <p>getRole.</p>
+     *
+     * @return a {@link java.lang.String} object.
      */
     public String getRole()
     {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/AdminScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/AdminScreen.java
@@ -6,35 +6,37 @@ import org.owasp.webgoat.session.Screen;
 import org.owasp.webgoat.session.WebSession;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public abstract class AdminScreen extends Screen
 {
@@ -46,7 +48,7 @@ public abstract class AdminScreen extends Screen
 
     /**
      * Constructor for the AdminScreen object
-     * 
+     *
      * @param s
      *            Description of the Parameter
      * @param q
@@ -61,7 +63,7 @@ public abstract class AdminScreen extends Screen
 
     /**
      * Constructor for the AdminScreen object
-     * 
+     *
      * @param s
      *            Description of the Parameter
      */
@@ -78,7 +80,7 @@ public abstract class AdminScreen extends Screen
 
     /**
      * Gets the title attribute of the AdminScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()
@@ -86,6 +88,11 @@ public abstract class AdminScreen extends Screen
         return ("Admin Information");
     }
 
+    /**
+     * <p>getRole.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getRole()
     {
         return AbstractLesson.ADMIN_ROLE;
@@ -93,7 +100,7 @@ public abstract class AdminScreen extends Screen
 
     /**
      * Sets the query attribute of the AdminScreen object
-     * 
+     *
      * @param q
      *            The new query value
      */

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/ProductsAdminScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/ProductsAdminScreen.java
@@ -13,35 +13,37 @@ import org.owasp.webgoat.session.DatabaseUtilities;
 import org.owasp.webgoat.session.WebSession;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class ProductsAdminScreen extends LessonAdapter
 {
@@ -49,11 +51,9 @@ public class ProductsAdminScreen extends LessonAdapter
     private final static String QUERY = "SELECT * FROM product_system_data";
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -84,7 +84,7 @@ public class ProductsAdminScreen extends LessonAdapter
 
     /**
      * Gets the category attribute of the ProductsAdminScreen object
-     * 
+     *
      * @return The category value
      */
     protected Category getDefaultCategory()
@@ -94,7 +94,7 @@ public class ProductsAdminScreen extends LessonAdapter
 
     /**
      * Gets the role attribute of the ProductsAdminScreen object
-     * 
+     *
      * @return The role value
      */
     public String getRole()
@@ -104,7 +104,7 @@ public class ProductsAdminScreen extends LessonAdapter
 
     /**
      * Gets the title attribute of the ProductsAdminScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()
@@ -114,6 +114,11 @@ public class ProductsAdminScreen extends LessonAdapter
 
     private final static Integer DEFAULT_RANKING = new Integer(1000);
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected Integer getDefaultRanking()
     {
         return DEFAULT_RANKING;

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/RefreshDBScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/RefreshDBScreen.java
@@ -13,35 +13,37 @@ import org.apache.ecs.html.Table;
 import org.owasp.webgoat.session.*;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class RefreshDBScreen extends LessonAdapter
 {
@@ -49,11 +51,9 @@ public class RefreshDBScreen extends LessonAdapter
     private final static String REFRESH = "Refresh";
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -98,7 +98,7 @@ public class RefreshDBScreen extends LessonAdapter
 
     /**
      * Gets the category attribute of the RefreshDBScreen object
-     * 
+     *
      * @return The category value
      */
     protected Category getDefaultCategory()
@@ -108,6 +108,11 @@ public class RefreshDBScreen extends LessonAdapter
 
     private final static Integer DEFAULT_RANKING = new Integer(1000);
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected Integer getDefaultRanking()
     {
         return DEFAULT_RANKING;
@@ -115,7 +120,7 @@ public class RefreshDBScreen extends LessonAdapter
 
     /**
      * Gets the role attribute of the RefreshDBScreen object
-     * 
+     *
      * @return The role value
      */
     public String getRole()
@@ -125,7 +130,7 @@ public class RefreshDBScreen extends LessonAdapter
 
     /**
      * Gets the title attribute of the RefreshDBScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()
@@ -135,7 +140,7 @@ public class RefreshDBScreen extends LessonAdapter
 
     /**
      * Description of the Method
-     * 
+     *
      * @param s
      *            Description of the Parameter
      */

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/ReportCardScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/ReportCardScreen.java
@@ -21,35 +21,37 @@ import org.owasp.webgoat.session.UserTracker;
 import org.owasp.webgoat.session.WebSession;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class ReportCardScreen extends LessonAdapter
 {
@@ -60,11 +62,9 @@ public class ReportCardScreen extends LessonAdapter
     protected final static String USERNAME = "Username";
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -108,7 +108,7 @@ public class ReportCardScreen extends LessonAdapter
 
     /**
      * Gets the category attribute of the UserAdminScreen object
-     * 
+     *
      * @return The category value
      */
     protected Category getDefaultCategory()
@@ -118,6 +118,11 @@ public class ReportCardScreen extends LessonAdapter
 
     private final static Integer DEFAULT_RANKING = new Integer(1000);
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected Integer getDefaultRanking()
     {
         return DEFAULT_RANKING;
@@ -125,7 +130,7 @@ public class ReportCardScreen extends LessonAdapter
 
     /**
      * Gets the role attribute of the UserAdminScreen object
-     * 
+     *
      * @return The role value
      */
     public String getRole()
@@ -135,7 +140,7 @@ public class ReportCardScreen extends LessonAdapter
 
     /**
      * Gets the title attribute of the UserAdminScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()
@@ -182,11 +187,9 @@ public class ReportCardScreen extends LessonAdapter
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element makeMessages(WebSession s)
     {
@@ -197,7 +200,7 @@ public class ReportCardScreen extends LessonAdapter
 
     /**
      * Description of the Method
-     * 
+     *
      * @param s
      *            Description of the Parameter
      * @param user
@@ -257,7 +260,7 @@ public class ReportCardScreen extends LessonAdapter
 
     /**
      * Description of the Method
-     * 
+     *
      * @param s
      *            Description of the Parameter
      * @param user

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/SummaryReportCardScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/SummaryReportCardScreen.java
@@ -22,35 +22,37 @@ import org.owasp.webgoat.session.UserTracker;
 import org.owasp.webgoat.session.WebSession;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Bruce mayhew <a href="http://code.google.com">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class SummaryReportCardScreen extends LessonAdapter
 {
@@ -60,11 +62,9 @@ public class SummaryReportCardScreen extends LessonAdapter
     private int totalUsersAdminComplete = 0;
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -123,6 +123,12 @@ public class SummaryReportCardScreen extends LessonAdapter
         return ec;
     }
 
+    /**
+     * <p>makeSummary.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link org.apache.ecs.Element} object.
+     */
     protected Element makeSummary(WebSession s)
     {
         Table t = new Table().setCellSpacing(0).setCellPadding(2).setBorder(0).setWidth("100%");
@@ -160,7 +166,7 @@ public class SummaryReportCardScreen extends LessonAdapter
 
     /**
      * Gets the category attribute of the UserAdminScreen object
-     * 
+     *
      * @return The category value
      */
     protected Category getDefaultCategory()
@@ -170,6 +176,11 @@ public class SummaryReportCardScreen extends LessonAdapter
 
     private final static Integer DEFAULT_RANKING = new Integer(1000);
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected Integer getDefaultRanking()
     {
         return DEFAULT_RANKING;
@@ -177,7 +188,7 @@ public class SummaryReportCardScreen extends LessonAdapter
 
     /**
      * Gets the role attribute of the UserAdminScreen object
-     * 
+     *
      * @return The role value
      */
     public String getRole()
@@ -187,7 +198,7 @@ public class SummaryReportCardScreen extends LessonAdapter
 
     /**
      * Gets the title attribute of the UserAdminScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()
@@ -196,11 +207,9 @@ public class SummaryReportCardScreen extends LessonAdapter
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element makeMessages(WebSession s)
     {
@@ -211,7 +220,7 @@ public class SummaryReportCardScreen extends LessonAdapter
 
     /**
      * Description of the Method
-     * 
+     *
      * @return Description of the Return Value
      */
     protected Element makeUserSummaryHeader()
@@ -229,7 +238,7 @@ public class SummaryReportCardScreen extends LessonAdapter
 
     /**
      * Description of the Method
-     * 
+     *
      * @param s
      *            Description of the Parameter
      * @param user
@@ -307,6 +316,11 @@ public class SummaryReportCardScreen extends LessonAdapter
         return (tr);
     }
 
+    /**
+     * <p>isEnterprise.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isEnterprise()
     {
         return true;

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/UserAdminScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/UserAdminScreen.java
@@ -13,35 +13,37 @@ import org.owasp.webgoat.session.DatabaseUtilities;
 import org.owasp.webgoat.session.WebSession;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class UserAdminScreen extends LessonAdapter
 {
@@ -49,11 +51,9 @@ public class UserAdminScreen extends LessonAdapter
     private final static String QUERY = "SELECT * FROM user_system_data";
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -84,7 +84,7 @@ public class UserAdminScreen extends LessonAdapter
 
     /**
      * Gets the category attribute of the UserAdminScreen object
-     * 
+     *
      * @return The category value
      */
     protected Category getDefaultCategory()
@@ -94,6 +94,11 @@ public class UserAdminScreen extends LessonAdapter
 
     private final static Integer DEFAULT_RANKING = new Integer(1000);
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected Integer getDefaultRanking()
     {
         return DEFAULT_RANKING;
@@ -101,7 +106,7 @@ public class UserAdminScreen extends LessonAdapter
 
     /**
      * Gets the role attribute of the UserAdminScreen object
-     * 
+     *
      * @return The role value
      */
     public String getRole()
@@ -111,7 +116,7 @@ public class UserAdminScreen extends LessonAdapter
 
     /**
      * Gets the title attribute of the UserAdminScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/ViewDatabase.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/ViewDatabase.java
@@ -15,35 +15,37 @@ import org.apache.ecs.html.Input;
 import org.owasp.webgoat.session.*;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class ViewDatabase extends LessonAdapter
 {
@@ -51,11 +53,9 @@ public class ViewDatabase extends LessonAdapter
     private final static String SQL = "sql";
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -100,7 +100,7 @@ public class ViewDatabase extends LessonAdapter
 
     /**
      * Gets the category attribute of the DatabaseScreen object
-     * 
+     *
      * @return The category value
      */
     protected Category getDefaultCategory()
@@ -110,15 +110,20 @@ public class ViewDatabase extends LessonAdapter
 
     private final static Integer DEFAULT_RANKING = new Integer(1000);
 
+    /**
+     * <p>getDefaultRanking.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
     protected Integer getDefaultRanking()
     {
         return DEFAULT_RANKING;
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Gets the hints attribute of the DatabaseScreen object
-     * 
-     * @return The hints value
      */
     protected List<String> getHints(WebSession s)
     {
@@ -129,9 +134,9 @@ public class ViewDatabase extends LessonAdapter
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Gets the instructions attribute of the ViewDatabase object
-     * 
-     * @return The instructions value
      */
     public String getInstructions(WebSession s)
     {
@@ -142,7 +147,7 @@ public class ViewDatabase extends LessonAdapter
 
     /**
      * Gets the role attribute of the ViewDatabase object
-     * 
+     *
      * @return The role value
      */
     public String getRole()
@@ -152,7 +157,7 @@ public class ViewDatabase extends LessonAdapter
 
     /**
      * Gets the title attribute of the DatabaseScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/WelcomeAdminScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/admin/WelcomeAdminScreen.java
@@ -9,42 +9,44 @@ import org.apache.ecs.html.H1;
 import org.owasp.webgoat.session.WebSession;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class WelcomeAdminScreen extends WelcomeScreen
 {
 
     /**
      * Constructor for the WelcomeAdminScreen object
-     * 
+     *
      * @param s
      *            Description of the Parameter
      */
@@ -61,11 +63,9 @@ public class WelcomeAdminScreen extends WelcomeScreen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * Description of the Method
-     * 
-     * @param s
-     *            Description of the Parameter
-     * @return Description of the Return Value
      */
     protected Element createContent(WebSession s)
     {
@@ -79,7 +79,7 @@ public class WelcomeAdminScreen extends WelcomeScreen
 
     /**
      * Gets the title attribute of the WelcomeAdminScreen object
-     * 
+     *
      * @return The title value
      */
     public String getTitle()

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/Hint.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/Hint.java
@@ -28,8 +28,10 @@
 package org.owasp.webgoat.lessons.model;
 
 /**
+ * <p>Hint class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public class Hint {
 
@@ -38,6 +40,8 @@ public class Hint {
     private int number;
 
     /**
+     * <p>Getter for the field <code>hint</code>.</p>
+     *
      * @return the hint
      */
     public String getHint() {
@@ -45,6 +49,8 @@ public class Hint {
     }
 
     /**
+     * <p>Setter for the field <code>hint</code>.</p>
+     *
      * @param hint the hint to set
      */
     public void setHint(String hint) {
@@ -52,6 +58,8 @@ public class Hint {
     }
 
     /**
+     * <p>Getter for the field <code>lesson</code>.</p>
+     *
      * @return the lesson
      */
     public String getLesson() {
@@ -59,6 +67,8 @@ public class Hint {
     }
 
     /**
+     * <p>Setter for the field <code>lesson</code>.</p>
+     *
      * @param lesson the lesson to set
      */
     public void setLesson(String lesson) {
@@ -66,6 +76,8 @@ public class Hint {
     }
 
     /**
+     * <p>Getter for the field <code>number</code>.</p>
+     *
      * @return the number
      */
     public int getNumber() {
@@ -73,6 +85,8 @@ public class Hint {
     }
 
     /**
+     * <p>Setter for the field <code>number</code>.</p>
+     *
      * @param number the number to set
      */
     public void setNumber(int number) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/HttpBasicsModel.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/HttpBasicsModel.java
@@ -30,18 +30,29 @@ package org.owasp.webgoat.lessons.model;
 /**
  * Model component for the Http Basics lesson.  Using a model
  * for that simple lesson is architectural overkill.  We do it anyway
- * for illustrative purposes - to demonstrate the pattern that we will 
+ * for illustrative purposes - to demonstrate the pattern that we will
  * use for more complex lessons.
- * 
+ *
+ * @version $Id: $Id
  */
 public class HttpBasicsModel {
 
     private String personName;
 
+    /**
+     * <p>Getter for the field <code>personName</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getPersonName() {
         return personName;
     }
 
+    /**
+     * <p>Setter for the field <code>personName</code>.</p>
+     *
+     * @param personName a {@link java.lang.String} object.
+     */
     public void setPersonName(String personName) {
         this.personName = personName;
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/LessonMenuItem.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/LessonMenuItem.java
@@ -34,8 +34,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * <p>LessonMenuItem class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public class LessonMenuItem {
 
@@ -48,6 +50,8 @@ public class LessonMenuItem {
     private boolean showHints = true;
 
     /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
      * @return the name
      */
     public String getName() {
@@ -55,6 +59,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
      * @param name the name to set
      */
     public void setName(String name) {
@@ -62,6 +68,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Getter for the field <code>children</code>.</p>
+     *
      * @return the children
      */
     public List<LessonMenuItem> getChildren() {
@@ -69,6 +77,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Setter for the field <code>children</code>.</p>
+     *
      * @param children the children to set
      */
     public void setChildren(List<LessonMenuItem> children) {
@@ -76,6 +86,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Getter for the field <code>type</code>.</p>
+     *
      * @return the type
      */
     public LessonMenuItemType getType() {
@@ -83,16 +95,24 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Setter for the field <code>type</code>.</p>
+     *
      * @param type the type to set
      */
     public void setType(LessonMenuItemType type) {
         this.type = type;
     }
 
+    /**
+     * <p>addChild.</p>
+     *
+     * @param child a {@link org.owasp.webgoat.lessons.model.LessonMenuItem} object.
+     */
     public void addChild(LessonMenuItem child) {
         children.add(child);
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         StringBuilder bldr = new StringBuilder();
@@ -102,6 +122,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>isComplete.</p>
+     *
      * @return the complete
      */
     public boolean isComplete() {
@@ -109,6 +131,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Setter for the field <code>complete</code>.</p>
+     *
      * @param complete the complete to set
      */
     public void setComplete(boolean complete) {
@@ -116,6 +140,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Getter for the field <code>link</code>.</p>
+     *
      * @return the link
      */
     public String getLink() {
@@ -123,6 +149,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Setter for the field <code>link</code>.</p>
+     *
      * @param link the link to set
      */
     public void setLink(String link) {
@@ -130,6 +158,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>isShowSource.</p>
+     *
      * @return the showSource
      */
     public boolean isShowSource() {
@@ -137,6 +167,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Setter for the field <code>showSource</code>.</p>
+     *
      * @param showSource the showSource to set
      */
     public void setShowSource(boolean showSource) {
@@ -144,6 +176,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>isShowHints.</p>
+     *
      * @return the showHints
      */
     public boolean isShowHints() {
@@ -151,6 +185,8 @@ public class LessonMenuItem {
     }
 
     /**
+     * <p>Setter for the field <code>showHints</code>.</p>
+     *
      * @param showHints the showHints to set
      */
     public void setShowHints(boolean showHints) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/LessonMenuItemType.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/LessonMenuItemType.java
@@ -29,8 +29,10 @@
 package org.owasp.webgoat.lessons.model;
 
 /**
+ * <p>LessonMenuItemType class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public enum LessonMenuItemType {
     CATEGORY,

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/RequestParameter.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/RequestParameter.java
@@ -31,20 +31,30 @@
 package org.owasp.webgoat.lessons.model;
 
 /**
+ * <p>RequestParameter class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public class RequestParameter implements Comparable<RequestParameter> {
 
     private final String name;
     private final String value;
 
+    /**
+     * <p>Constructor for RequestParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param value a {@link java.lang.String} object.
+     */
     public RequestParameter(String name, String value) {
         this.name = name;
         this.value = value;
     }
 
     /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
      * @return the name
      */
     public String getName() {
@@ -52,12 +62,15 @@ public class RequestParameter implements Comparable<RequestParameter> {
     }
 
     /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
      * @return the values
      */
     public String getValue() {
         return value;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int compareTo(RequestParameter o) {
         return this.name.compareTo(o.getName());

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/SourceListing.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/model/SourceListing.java
@@ -7,14 +7,18 @@
 package org.owasp.webgoat.lessons.model;
 
 /**
+ * <p>SourceListing class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public class SourceListing {
     
     private String source;
 
     /**
+     * <p>Getter for the field <code>source</code>.</p>
+     *
      * @return the source
      */
     public String getSource() {
@@ -22,6 +26,8 @@ public class SourceListing {
     }
 
     /**
+     * <p>Setter for the field <code>source</code>.</p>
+     *
      * @param source the source to set
      */
     public void setSource(String source) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/plugins/LegacyLoader.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/plugins/LegacyLoader.java
@@ -14,37 +14,36 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * *************************************************************************************************
- * <p/>
- * <p/>
- * This file is part of WebGoat, an Open Web Application Security Project
- * utility. For details, please see http://www.owasp.org/
- * <p/>
+ *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * <p/>
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * <p/>
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * <p/>
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- * <p/>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
  * Getting Source ==============
- * <p/>
- * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
- * for free software projects.
- * <p/>
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ *
  * For details, please see http://webgoat.github.io
  *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class LegacyLoader {
 
@@ -52,12 +51,15 @@ public class LegacyLoader {
 
     private final List<String> files = new LinkedList<String>();
 
+    /**
+     * <p>Constructor for LegacyLoader.</p>
+     */
     public LegacyLoader() {
     }
 
     /**
      * Take an absolute file and return the filename.
-     * <p/>
+     *
      * Ex. /etc/password becomes password
      *
      * @param s
@@ -79,7 +81,7 @@ public class LegacyLoader {
 
     /**
      * Take a class name and return the equivalent file name
-     * <p/>
+     *
      * Ex. org.owasp.webgoat becomes org/owasp/webgoat.java
      *
      * @param className
@@ -137,8 +139,8 @@ public class LegacyLoader {
     /**
      * Load all of the filenames into a temporary cache
      *
-     * @param context
-     * @param path
+     * @param context a {@link javax.servlet.ServletContext} object.
+     * @param path a {@link java.lang.String} object.
      */
     public void loadFiles(ServletContext context, String path) {
         logger.debug("Loading files into cache, path: " + path);
@@ -163,8 +165,11 @@ public class LegacyLoader {
     /**
      * Instantiate all the lesson objects into a cache
      *
-     * @param path
-     * @param context 
+     * @param path a {@link java.lang.String} object.
+     * @param context a {@link javax.servlet.ServletContext} object.
+     * @param webgoatContext a {@link org.owasp.webgoat.session.WebgoatContext} object.
+     * @param properties a {@link org.owasp.webgoat.session.WebgoatProperties} object.
+     * @return a {@link java.util.List} object.
      */
     public List<AbstractLesson> loadLessons(WebgoatContext webgoatContext, ServletContext context, String path, WebgoatProperties properties ) {
 
@@ -214,7 +219,8 @@ public class LegacyLoader {
 
     /**
      * For each lesson, set the source file and lesson file
-     * @param lessons 
+     *
+     * @param lessons a {@link java.util.List} object.
      */
     public void loadResources(List<AbstractLesson> lessons ) {
         for (AbstractLesson lesson : lessons) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/plugins/Plugin.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/plugins/Plugin.java
@@ -20,6 +20,11 @@ import static org.owasp.webgoat.plugins.PluginFileUtils.fileEndsWith;
 import static org.owasp.webgoat.plugins.PluginFileUtils.hasParentDirectoryWithName;
 import static org.owasp.webgoat.plugins.PluginFileUtils.replaceInFiles;
 
+/**
+ * <p>Plugin class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class Plugin {
 
     private static final String NAME_LESSON_SOLUTION_DIRECTORY = "lessonSolutions";
@@ -32,12 +37,23 @@ public class Plugin {
     private List<File> pluginFiles = Lists.newArrayList();
     private File lessonSourceFile;
 
+    /**
+     * <p>Constructor for Plugin.</p>
+     *
+     * @param pluginDirectory a {@link java.nio.file.Path} object.
+     */
     public Plugin(Path pluginDirectory) {
         Preconditions.checkNotNull(pluginDirectory, "plugin directory cannot be null");
         Preconditions.checkArgument(Files.exists(pluginDirectory), "directory %s does not exists", pluginDirectory);
         this.pluginDirectory = pluginDirectory;
     }
 
+    /**
+     * <p>Constructor for Plugin.</p>
+     *
+     * @param pluginDirectory a {@link java.nio.file.Path} object.
+     * @param classes a {@link java.util.List} object.
+     */
     public Plugin(Path pluginDirectory, List<String> classes) {
         this(pluginDirectory);
         findLesson(classes);
@@ -65,6 +81,11 @@ public class Plugin {
         }
     }
 
+    /**
+     * <p>loadProperties.</p>
+     *
+     * @param properties a {@link java.util.List} object.
+     */
     public void loadProperties(List<Path> properties) {
         for (Path propertyFile : properties) {
             LabelProvider.updatePluginResources(propertyFile);
@@ -72,6 +93,12 @@ public class Plugin {
         }
     }
 
+    /**
+     * <p>loadFiles.</p>
+     *
+     * @param files a {@link java.util.List} object.
+     * @param reload a boolean.
+     */
     public void loadFiles(List<Path> files, boolean reload) {
         for (Path file : files) {
             if (fileEndsWith(file, ".html") && hasParentDirectoryWithName(file, NAME_LESSON_SOLUTION_DIRECTORY)) {
@@ -90,6 +117,11 @@ public class Plugin {
         }
     }
 
+    /**
+     * <p>rewritePaths.</p>
+     *
+     * @param pluginTarget a {@link java.nio.file.Path} object.
+     */
     public void rewritePaths(Path pluginTarget) {
         try {
             replaceInFiles(this.lesson.getSimpleName() + "_files",
@@ -125,6 +157,8 @@ public class Plugin {
 
     /**
      * Lesson is optional, it is also possible that the supplied jar contains only helper classes.
+     *
+     * @return a {@link com.google.common.base.Optional} object.
      */
     public Optional<AbstractLesson> getLesson() {
         try {
@@ -137,18 +171,39 @@ public class Plugin {
         return Optional.absent();
     }
 
+    /**
+     * <p>getLessonSolution.</p>
+     *
+     * @param language a {@link java.lang.String} object.
+     * @return a {@link com.google.common.base.Optional} object.
+     */
     public Optional<File> getLessonSolution(String language) {
         return Optional.fromNullable(this.solutionLanguageFiles.get(language));
     }
 
+    /**
+     * <p>getLessonSolutions.</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, File> getLessonSolutions() {
         return this.solutionLanguageFiles;
     }
 
+    /**
+     * <p>getLessonSource.</p>
+     *
+     * @return a {@link com.google.common.base.Optional} object.
+     */
     public Optional<File> getLessonSource() {
         return Optional.fromNullable(lessonSourceFile);
     }
 
+    /**
+     * <p>getLessonPlans.</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, File> getLessonPlans() {
         return this.lessonPlansLanguageFiles;
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginBackgroundLoader.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginBackgroundLoader.java
@@ -9,10 +9,16 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @WebListener
+/**
+ * <p>PluginBackgroundLoader class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class PluginBackgroundLoader implements ServletContextListener {
 
     private ScheduledExecutorService scheduler;
 
+    /** {@inheritDoc} */
     @Override
     public void contextInitialized(ServletContextEvent event) {
         String pluginPath = event.getServletContext().getRealPath("plugin_lessons");
@@ -22,6 +28,7 @@ public class PluginBackgroundLoader implements ServletContextListener {
         scheduler.scheduleAtFixedRate(new PluginsLoader(Paths.get(pluginPath), Paths.get(targetPath)), 0, 5, TimeUnit.MINUTES);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void contextDestroyed(ServletContextEvent event) {
         scheduler.shutdownNow();

--- a/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginExtractor.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginExtractor.java
@@ -25,6 +25,8 @@ import static org.owasp.webgoat.plugins.PluginFileUtils.hasParentDirectoryWithNa
 /**
  * Extract the jar file and place them in the system temp directory in the folder webgoat and collect the files
  * and classes.
+ *
+ * @version $Id: $Id
  */
 public class PluginExtractor {
 
@@ -34,10 +36,20 @@ public class PluginExtractor {
     private final List<Path> files = new ArrayList<>();
     private final List<Path> properties = new ArrayList<>();
 
+    /**
+     * <p>Constructor for PluginExtractor.</p>
+     *
+     * @param pluginArchive a {@link java.nio.file.Path} object.
+     */
     public PluginExtractor(Path pluginArchive) {
         this.pluginArchive = pluginArchive;
     }
 
+    /**
+     * <p>extract.</p>
+     *
+     * @param target a {@link java.nio.file.Path} object.
+     */
     public void extract(final Path target) {
         try (FileSystem zip = createZipFileSystem()) {
             final Path root = zip.getPath("/");
@@ -63,14 +75,29 @@ public class PluginExtractor {
         }
     }
 
+    /**
+     * <p>Getter for the field <code>classes</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<String> getClasses() {
         return this.classes;
     }
 
+    /**
+     * <p>Getter for the field <code>files</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Path> getFiles() {
         return this.files;
     }
 
+    /**
+     * <p>Getter for the field <code>properties</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Path> getProperties() {
         return this.properties;
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginFileUtils.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginFileUtils.java
@@ -14,12 +14,31 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * <p>PluginFileUtils class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class PluginFileUtils {
 
+    /**
+     * <p>fileEndsWith.</p>
+     *
+     * @param p a {@link java.nio.file.Path} object.
+     * @param s a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public static boolean fileEndsWith(Path p, String s) {
         return p.getFileName().toString().endsWith(s);
     }
 
+    /**
+     * <p>fileEndsWith.</p>
+     *
+     * @param p a {@link java.nio.file.Path} object.
+     * @param suffixes a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public static boolean fileEndsWith(Path p, String... suffixes) {
         for (String suffix : suffixes) {
             if (fileEndsWith(p, suffix)) {
@@ -29,6 +48,13 @@ public class PluginFileUtils {
         return false;
     }
 
+    /**
+     * <p>hasParentDirectoryWithName.</p>
+     *
+     * @param p a {@link java.nio.file.Path} object.
+     * @param s a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public static boolean hasParentDirectoryWithName(Path p, String s) {
         if (p == null || p.getParent() == null || p.getParent().equals(p.getRoot())) {
             return false;
@@ -39,6 +65,13 @@ public class PluginFileUtils {
         return hasParentDirectoryWithName(p.getParent(), s);
     }
 
+    /**
+     * <p>createDirsIfNotExists.</p>
+     *
+     * @param p a {@link java.nio.file.Path} object.
+     * @return a {@link java.nio.file.Path} object.
+     * @throws java.io.IOException if any.
+     */
     public static Path createDirsIfNotExists(Path p) throws IOException {
         if (Files.notExists(p)) {
             Files.createDirectories(p);
@@ -46,6 +79,13 @@ public class PluginFileUtils {
         return p;
     }
 
+    /**
+     * <p>getFilesInDirectory.</p>
+     *
+     * @param directory a {@link java.nio.file.Path} object.
+     * @return a {@link java.util.List} object.
+     * @throws java.io.IOException if any.
+     */
     public static List<Path> getFilesInDirectory(Path directory) throws IOException {
         List<Path> files = new ArrayList<>();
         DirectoryStream<Path> dirStream;
@@ -57,6 +97,14 @@ public class PluginFileUtils {
         return files;
     }
 
+    /**
+     * <p>replaceInFiles.</p>
+     *
+     * @param replace a {@link java.lang.String} object.
+     * @param with a {@link java.lang.String} object.
+     * @param files a {@link java.util.Collection} object.
+     * @throws java.io.IOException if any.
+     */
     public static void replaceInFiles(String replace, String with, Collection<File> files) throws IOException {
         Preconditions.checkNotNull(replace);
         Preconditions.checkNotNull(with);
@@ -67,6 +115,14 @@ public class PluginFileUtils {
         }
     }
 
+    /**
+     * <p>replaceInFile.</p>
+     *
+     * @param replace a {@link java.lang.String} object.
+     * @param with a {@link java.lang.String} object.
+     * @param file a {@link java.nio.file.Path} object.
+     * @throws java.io.IOException if any.
+     */
     public static void replaceInFile(String replace, String with, Path file) throws IOException {
         Preconditions.checkNotNull(replace);
         Preconditions.checkNotNull(with);
@@ -78,6 +134,14 @@ public class PluginFileUtils {
         Files.write(file, fileAsString.getBytes());
     }
 
+    /**
+     * <p>writeFile.</p>
+     *
+     * @param targetFile a {@link java.nio.file.Path} object.
+     * @param bytes an array of byte.
+     * @param options a {@link java.nio.file.OpenOption} object.
+     * @throws java.io.IOException if any.
+     */
     public static void writeFile(Path targetFile, byte[] bytes, OpenOption... options) throws IOException {
         createDirsIfNotExists(targetFile.getParent());
         if (!Files.exists(targetFile)) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginLoadingFailure.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginLoadingFailure.java
@@ -1,7 +1,18 @@
 package org.owasp.webgoat.plugins;
 
+/**
+ * <p>PluginLoadingFailure class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class PluginLoadingFailure extends RuntimeException {
 
+    /**
+     * <p>Constructor for PluginLoadingFailure.</p>
+     *
+     * @param message a {@link java.lang.String} object.
+     * @param e a {@link java.lang.Exception} object.
+     */
     public PluginLoadingFailure(String message, Exception e) {
         super(message, e);
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginsLoader.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/plugins/PluginsLoader.java
@@ -22,14 +22,26 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+/**
+ * <p>PluginsLoader class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class PluginsLoader implements Runnable {
 
+    /** Constant <code>WEBGOAT_PLUGIN_EXTENSION="jar"</code> */
     protected static final String WEBGOAT_PLUGIN_EXTENSION = "jar";
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final Path pluginSource;
     private Path pluginTarget;
 
 
+    /**
+     * <p>Constructor for PluginsLoader.</p>
+     *
+     * @param pluginSource a {@link java.nio.file.Path} object.
+     * @param pluginTarget a {@link java.nio.file.Path} object.
+     */
     public PluginsLoader(Path pluginSource, Path pluginTarget) {
         Preconditions.checkNotNull(pluginSource, "plugin source cannot be null");
         Preconditions.checkNotNull(pluginTarget, "plugin target cannot be null");
@@ -38,6 +50,12 @@ public class PluginsLoader implements Runnable {
         this.pluginTarget = pluginTarget;
     }
 
+    /**
+     * <p>loadPlugins.</p>
+     *
+     * @param reload a boolean.
+     * @return a {@link java.util.List} object.
+     */
     public List<Plugin> loadPlugins(final boolean reload) {
         final PluginClassLoader cl = (PluginClassLoader) Thread.currentThread().getContextClassLoader();
         List<Plugin> plugins = Lists.newArrayList();
@@ -109,6 +127,7 @@ public class PluginsLoader implements Runnable {
         return extractorCallables;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void run() {
         loadPlugins(true);

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/ApplicationService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/ApplicationService.java
@@ -37,8 +37,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>ApplicationService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class ApplicationService extends BaseService {
@@ -46,8 +48,8 @@ public class ApplicationService extends BaseService {
     /**
      * Returns global application info
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link org.owasp.webgoat.application.Application} object.
      */
     @RequestMapping(value = "/application.mvc", produces = "application/json")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/BaseService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/BaseService.java
@@ -44,14 +44,23 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
+ * <p>Abstract BaseService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @RequestMapping("/service")
 public abstract class BaseService {
 
     private static final Logger logger = LoggerFactory.getLogger(BaseService.class);
 
+    /**
+     * <p>handleException.</p>
+     *
+     * @param request a {@link javax.servlet.http.HttpServletRequest} object.
+     * @param ex a {@link java.lang.Exception} object.
+     * @return a {@link org.owasp.webgoat.service.ExceptionInfo} object.
+     */
     @ExceptionHandler(Exception.class)
     @ResponseStatus(value = HttpStatus.I_AM_A_TEAPOT)
     public @ResponseBody
@@ -66,6 +75,12 @@ public abstract class BaseService {
         return response;
     }
 
+    /**
+     * <p>getWebSession.</p>
+     *
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link org.owasp.webgoat.session.WebSession} object.
+     */
     public WebSession getWebSession(HttpSession session) {
         WebSession ws;
         Object o = session.getAttribute(WebSession.SESSION);
@@ -79,6 +94,12 @@ public abstract class BaseService {
         return ws;
     }
 
+    /**
+     * <p>getStringStackTrace.</p>
+     *
+     * @param t a {@link java.lang.Throwable} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String getStringStackTrace(Throwable t){
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/CookieService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/CookieService.java
@@ -42,8 +42,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
+ * <p>CookieService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class CookieService extends BaseService {
@@ -51,8 +53,8 @@ public class CookieService extends BaseService {
     /**
      * Returns cookies for last attack
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.util.List} object.
      */
     @RequestMapping(value = "/cookie.mvc", produces = "application/json")
     public @ResponseBody
@@ -65,8 +67,8 @@ public class CookieService extends BaseService {
     /**
      * Returns cookies and params for current lesson
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link org.springframework.web.servlet.ModelAndView} object.
      */
     @RequestMapping(value = "/cookies_widget.mvc", produces = "text/html")
     public ModelAndView showCookiesAndParamsAsHtml(HttpSession session) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/DummyService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/DummyService.java
@@ -34,12 +34,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>DummyService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class DummyService extends BaseService{
 
+    /**
+     * <p>firstNames.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     @RequestMapping(value = "/first.mvc", produces = "application/json")
     public @ResponseBody
     List<String> firstNames() {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/ExceptionInfo.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/ExceptionInfo.java
@@ -28,26 +28,48 @@
 package org.owasp.webgoat.service;
 
 /**
+ * <p>ExceptionInfo class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 public class ExceptionInfo {
 
     private String url;
     private String message;
 
+    /**
+     * <p>Getter for the field <code>url</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getUrl() {
         return url;
     }
 
+    /**
+     * <p>Setter for the field <code>url</code>.</p>
+     *
+     * @param url a {@link java.lang.String} object.
+     */
     public void setUrl(String url) {
         this.url = url;
     }
 
+    /**
+     * <p>Getter for the field <code>message</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getMessage() {
         return message;
     }
 
+    /**
+     * <p>Setter for the field <code>message</code>.</p>
+     *
+     * @param message a {@link java.lang.String} object.
+     */
     public void setMessage(String message) {
         this.message = message;
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/HintService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/HintService.java
@@ -17,8 +17,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
+ * <p>HintService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class HintService extends BaseService {
@@ -26,8 +28,8 @@ public class HintService extends BaseService {
     /**
      * Returns hints for current lesson
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.util.List} object.
      */
     @RequestMapping(value = "/hint.mvc", produces = "application/json")
     public @ResponseBody
@@ -55,6 +57,12 @@ public class HintService extends BaseService {
         return listHints;
     }
 
+    /**
+     * <p>showHintsAsHtml.</p>
+     *
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link org.springframework.web.servlet.ModelAndView} object.
+     */
     @RequestMapping(value = "/hint_widget.mvc", produces = "text/html")
     public
             ModelAndView showHintsAsHtml(HttpSession session) {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
@@ -47,8 +47,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>LessonMenuService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class LessonMenuService extends BaseService {
@@ -58,8 +60,8 @@ public class LessonMenuService extends BaseService {
     /**
      * Returns the lesson menu which is used to build the left nav
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.util.List} object.
      */
     @RequestMapping(value = "/lessonmenu.mvc", produces = "application/json")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonPlanService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonPlanService.java
@@ -42,8 +42,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>LessonPlanService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class LessonPlanService extends BaseService {
@@ -51,8 +53,8 @@ public class LessonPlanService extends BaseService {
     /**
      * Returns source for current attack
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.lang.String} object.
      */
     @RequestMapping(value = "/lessonplan.mvc", produces = "application/html")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonTitleService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonTitleService.java
@@ -10,13 +10,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
+/**
+ * <p>LessonTitleService class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class LessonTitleService extends BaseService {
 	
-	 /**
+    /**
      * Returns the title for the current attack
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.lang.String} object.
      */
     @RequestMapping(value = "/lessontitle.mvc", produces = "application/html")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/ParameterService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/ParameterService.java
@@ -43,8 +43,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>ParameterService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class ParameterService extends BaseService {
@@ -54,8 +56,8 @@ public class ParameterService extends BaseService {
     /**
      * Returns request parameters for last attack
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.util.List} object.
      */
     @RequestMapping(value = "/parameter.mvc", produces = "application/json")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/RestartLessonService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/RestartLessonService.java
@@ -34,8 +34,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>RestartLessonService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class RestartLessonService extends BaseService {
@@ -43,8 +45,8 @@ public class RestartLessonService extends BaseService {
     /**
      * Returns current lesson
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.lang.String} object.
      */
     @RequestMapping(value = "/restartlesson.mvc", produces = "text/text")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/SessionService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/SessionService.java
@@ -17,8 +17,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>SessionService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class SessionService extends BaseService {
@@ -26,8 +28,9 @@ public class SessionService extends BaseService {
     /**
      * Returns hints for current lesson
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @param request a {@link javax.servlet.http.HttpServletRequest} object.
+     * @return a {@link java.lang.String} object.
      */
     @RequestMapping(value = "/session.mvc", produces = "application/json")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/SolutionService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/SolutionService.java
@@ -39,8 +39,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
+ * <p>SolutionService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class SolutionService extends BaseService {
@@ -48,8 +50,8 @@ public class SolutionService extends BaseService {
     /**
      * Returns solution for current attack
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.lang.String} object.
      */
     @RequestMapping(value = "/solution.mvc", produces = "text/html")
     public @ResponseBody
@@ -59,6 +61,12 @@ public class SolutionService extends BaseService {
         return source;
     }
 
+    /**
+     * <p>getSolution.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.lang.String} object.
+     */
     protected String getSolution(WebSession s) {
 
         String source = null;

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/SourceService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/SourceService.java
@@ -44,8 +44,10 @@ import static org.owasp.webgoat.LessonSource.END_SOURCE_SKIP;
 import static org.owasp.webgoat.LessonSource.START_SOURCE_SKIP;
 
 /**
+ * <p>SourceService class.</p>
  *
  * @author rlawson
+ * @version $Id: $Id
  */
 @Controller
 public class SourceService extends BaseService {
@@ -53,8 +55,8 @@ public class SourceService extends BaseService {
     /**
      * Returns source for current attack
      *
-     * @param session
-     * @return
+     * @param session a {@link javax.servlet.http.HttpSession} object.
+     * @return a {@link java.lang.String} object.
      */
     @RequestMapping(value = "/source.mvc", produces = "application/text")
     public @ResponseBody

--- a/webgoat-container/src/main/java/org/owasp/webgoat/servlets/Controller.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/servlets/Controller.java
@@ -1,1 +1,72 @@
-package org.owasp.webgoat.servlets;import java.io.IOException;import javax.servlet.ServletException;import javax.servlet.http.HttpServlet;import javax.servlet.http.HttpServletRequest;import javax.servlet.http.HttpServletResponse;/** * ************************************************************************************************* * * * This file is part of WebGoat, an Open Web Application Security Project * utility. For details, please see http://www.owasp.org/ * * Copyright (c) 2002 - 20014 Bruce Mayhew * * This program is free software; you can redistribute it and/or modify it under * the terms of the GNU General Public License as published by the Free Software * Foundation; either version 2 of the License, or (at your option) any later * version. * * This program is distributed in the hope that it will be useful, but WITHOUT * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more * details. * * You should have received a copy of the GNU General Public License along with * this program; if not, write to the Free Software Foundation, Inc., 59 Temple * Place - Suite 330, Boston, MA 02111-1307, USA. * * Getting Source ============== * * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository * for free software projects. * * For details, please see http://webgoat.github.io */public class Controller extends HttpServlet {    private static final long serialVersionUID = 1L;    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {        doPost(request, response);    }    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException,            IOException {        String userAgent = request.getHeader("user-agent");        String clientBrowser = "Not known!";        if (userAgent != null) {            clientBrowser = userAgent;        }        request.setAttribute("client.browser", clientBrowser);        request.getRequestDispatcher("/view.jsp").forward(request, response);    }}
+package org.owasp.webgoat.servlets;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project
+ * utility. For details, please see http://www.owasp.org/
+ *
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * Getting Source ==============
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
+ * for free software projects.
+ *
+ * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
+ */
+public class Controller extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    /** {@inheritDoc} */
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        doPost(request, response);
+
+    }
+
+    /** {@inheritDoc} */
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException,
+            IOException {
+
+        String userAgent = request.getHeader("user-agent");
+
+        String clientBrowser = "Not known!";
+
+        if (userAgent != null) {
+
+            clientBrowser = userAgent;
+
+        }
+
+        request.setAttribute("client.browser", clientBrowser);
+
+        request.getRequestDispatcher("/view.jsp").forward(request, response);
+
+    }
+
+}

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/Authorization.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/Authorization.java
@@ -5,47 +5,66 @@ import java.util.Hashtable;
 import java.util.Map;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * * @version $Id: $Id
  */
 public class Authorization
 {
 
 	Map<Integer, Integer> permissions = new Hashtable<Integer, Integer>();
 
+	/**
+	 * <p>Constructor for Authorization.</p>
+	 */
 	public Authorization()
 	{
 	}
 
+	/**
+	 * <p>setPermission.</p>
+	 *
+	 * @param userId a int.
+	 * @param functionId a int.
+	 */
 	public void setPermission(int userId, int functionId)
 	{
 		permissions.put(new Integer(userId), new Integer(functionId));
 	}
 
+	/**
+	 * <p>isAllowed.</p>
+	 *
+	 * @param userId a int.
+	 * @param functionId a int.
+	 * @return a boolean.
+	 */
 	public boolean isAllowed(int userId, int functionId)
 	{
 		return (permissions.get(new Integer(userId)) != null);

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/Course.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/Course.java
@@ -30,37 +30,36 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * *************************************************************************************************
- * <p/>
- * <p/>
- * This file is part of WebGoat, an Open Web Application Security Project
- * utility. For details, please see http://www.owasp.org/
- * <p/>
+ *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * <p/>
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * <p/>
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
- * <p/>
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
- * Place - Suite 330, Boston, MA 02111-1307, USA.
- * <p/>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
  * Getting Source ==============
- * <p/>
- * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
- * for free software projects.
- * <p/>
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ *
  * For details, please see http://webgoat.github.io
  *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class Course {
 
@@ -76,6 +75,9 @@ public class Course {
 
     private WebgoatContext webgoatContext;
 
+    /**
+     * <p>Constructor for Course.</p>
+     */
     public Course() {
         try {
             properties = new WebgoatProperties(PROPERTIES_FILENAME);
@@ -86,7 +88,7 @@ public class Course {
 
     /**
      * Take an absolute file and return the filename.
-     * <p/>
+     *
      * Ex. /etc/password becomes password
      *
      * @param s
@@ -108,7 +110,7 @@ public class Course {
 
     /**
      * Take a class name and return the equivalent file name
-     * <p/>
+     *
      * Ex. org.owasp.webgoat becomes org/owasp/webgoat.java
      *
      * @param className
@@ -190,9 +192,9 @@ public class Course {
     /**
      * Gets the lesson attribute of the Course object
      *
-     * @param s
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
      * @param lessonId Description of the Parameter
-     * @param roles
+     * @param roles a {@link java.util.List} object.
      * @return The lesson value
      */
     public AbstractLesson getLesson(WebSession s, int lessonId, List<String> roles) {
@@ -214,12 +216,27 @@ public class Course {
         return null;
     }
 
+    /**
+     * <p>getLesson.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param lessonId a int.
+     * @param role a {@link java.lang.String} object.
+     * @return a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     */
     public AbstractLesson getLesson(WebSession s, int lessonId, String role) {
         List<String> roles = new ArrayList<String>();
         roles.add(role);
         return getLesson(s, lessonId, roles);
     }
 
+    /**
+     * <p>Getter for the field <code>lessons</code>.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param role a {@link java.lang.String} object.
+     * @return a {@link java.util.List} object.
+     */
     public List getLessons(WebSession s, String role) {
         List<String> roles = new ArrayList<String>();
         roles.add(role);
@@ -229,8 +246,8 @@ public class Course {
     /**
      * Gets the lessons attribute of the Course object
      *
-     * @param s
-     * @param roles
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param roles a {@link java.util.List} object.
      * @return The lessons value
      */
     public List<AbstractLesson> getLessons(WebSession s, List<String> roles) {
@@ -266,12 +283,28 @@ public class Course {
         return lessonList;
     }
 
+    /**
+     * <p>Getter for the field <code>lessons</code>.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param category a {@link org.owasp.webgoat.lessons.Category} object.
+     * @param role a {@link java.lang.String} object.
+     * @return a {@link java.util.List} object.
+     */
     public List getLessons(WebSession s, Category category, String role) {
         List<String> roles = new ArrayList<String>();
         roles.add(role);
         return getLessons(s, category, roles);
     }
 
+    /**
+     * <p>Getter for the field <code>lessons</code>.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param category a {@link org.owasp.webgoat.lessons.Category} object.
+     * @param roles a {@link java.util.List} object.
+     * @return a {@link java.util.List} object.
+     */
     public List<AbstractLesson> getLessons(WebSession s, Category category, List<String> roles) {
         if (s.isHackedAdmin()) {
             roles.add(AbstractLesson.HACKED_ADMIN_ROLE);
@@ -279,6 +312,12 @@ public class Course {
         return getLessons(category, roles);
     }
 
+    /**
+     * <p>getLesson.</p>
+     *
+     * @param lessonId a int.
+     * @return a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     */
     public AbstractLesson getLesson(int lessonId) {
         for (AbstractLesson l : lessons) {
             if (l.getScreenId() == lessonId) {
@@ -326,7 +365,7 @@ public class Course {
     /**
      * Description of the Method
      *
-     * @param webgoatContext
+     * @param webgoatContext a {@link org.owasp.webgoat.session.WebgoatContext} object.
      * @param path           Description of the Parameter
      * @param context        Description of the Parameter
      */

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/CreateDB.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/CreateDB.java
@@ -7,34 +7,36 @@ import java.sql.Statement;
 import org.owasp.webgoat.lessons.AbstractLesson;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
+ * @version $Id: $Id
  */
 public class CreateDB
 {
@@ -1007,12 +1009,12 @@ public class CreateDB
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param connection
 	 *            Description of the Parameter
-	 * 
 	 * @exception SQLException
 	 *                Description of the Exception
+	 * @throws java.sql.SQLException if any.
 	 */
 	public void makeDB(Connection connection) throws SQLException
 	{

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/DatabaseUtilities.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/DatabaseUtilities.java
@@ -16,34 +16,36 @@ import org.apache.ecs.html.TR;
 import org.apache.ecs.html.Table;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
+ * @version $Id: $Id
  */
 public class DatabaseUtilities
 {
@@ -51,11 +53,26 @@ public class DatabaseUtilities
 	private static Map<String, Connection> connections = new HashMap<String, Connection>();
 	private static Map<String, Boolean> dbBuilt = new HashMap<String, Boolean>();
 
+	/**
+	 * <p>getConnection.</p>
+	 *
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+	 * @return a {@link java.sql.Connection} object.
+	 * @throws java.sql.SQLException if any.
+	 */
 	public static Connection getConnection(WebSession s) throws SQLException
 	{
 		return getConnection(s.getUserName(), s.getWebgoatContext());
 	}
 
+	/**
+	 * <p>getConnection.</p>
+	 *
+	 * @param user a {@link java.lang.String} object.
+	 * @param context a {@link org.owasp.webgoat.session.WebgoatContext} object.
+	 * @return a {@link java.sql.Connection} object.
+	 * @throws java.sql.SQLException if any.
+	 */
 	public static synchronized Connection getConnection(String user, WebgoatContext context) throws SQLException
 	{
 		Connection conn = connections.get(user);
@@ -72,6 +89,11 @@ public class DatabaseUtilities
 		return conn;
 	}
 
+	/**
+	 * <p>returnConnection.</p>
+	 *
+	 * @param user a {@link java.lang.String} object.
+	 */
 	public static synchronized void returnConnection(String user)
 	{
 		try
@@ -114,18 +136,20 @@ public class DatabaseUtilities
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param results
 	 *            Description of the Parameter
 	 * @param resultsMetaData
 	 *            Description of the Parameter
-	 * 
+	 * @param resultsMetaData
+	 *            Description of the Parameter
 	 * @return Description of the Return Value
-	 * 
 	 * @exception IOException
 	 *                Description of the Exception
 	 * @exception SQLException
 	 *                Description of the Exception
+	 * @throws java.io.IOException if any.
+	 * @throws java.sql.SQLException if any.
 	 */
 	public static MultiPartElement writeTable(ResultSet results, ResultSetMetaData resultsMetaData) throws IOException,
 			SQLException

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/ECSFactory.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/ECSFactory.java
@@ -22,37 +22,38 @@ import org.apache.ecs.html.TR;
 import org.apache.ecs.html.U;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams (jeff.williams@aspectsecurity.com)
- * @created October 29, 2003
+ * @since October 29, 2003
+ * @version $Id: $Id
  */
-
 public class ECSFactory
 {
 
@@ -78,14 +79,13 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param name
 	 *            Description of the Parameter
 	 * @param value
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makeBox(String name, String value)
 	{
 
@@ -98,12 +98,11 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param text
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makeButton(String text)
 	{
 
@@ -116,6 +115,13 @@ public class ECSFactory
 		return (b);
 	}
 
+	/**
+	 * <p>makeButton.</p>
+	 *
+	 * @param text a {@link java.lang.String} object.
+	 * @param onClickFunction a {@link java.lang.String} object.
+	 * @return a {@link org.apache.ecs.Element} object.
+	 */
 	public static Element makeButton(String text, String onClickFunction)
 	{
 
@@ -127,7 +133,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param labeltext
 	 *            Description of the Parameter
 	 * @param value
@@ -136,7 +142,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static TR makeField(String labeltext, String value, Element e)
 	{
 
@@ -161,7 +166,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param labeltext
 	 *            Description of the Parameter
 	 * @param name
@@ -172,7 +177,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static TR makeField(String labeltext, String name, String value, int size)
 	{
 
@@ -192,7 +196,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param label
 	 *            Description of the Parameter
 	 * @param type
@@ -207,7 +211,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makeInput(String label, String type, String name, boolean value, boolean selected,
 			String alignment)
 	{
@@ -217,7 +220,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param label
 	 *            Description of the Parameter
 	 * @param type
@@ -228,7 +231,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makeInput(String label, String type, String name, String value)
 	{
 
@@ -237,7 +239,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param label
 	 *            Description of the Parameter
 	 * @param type
@@ -252,7 +254,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makeInput(String label, String type, String name, String value, boolean selected,
 			String alignment)
 	{
@@ -289,7 +290,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param text
 	 *            Description of the Parameter
 	 * @param name
@@ -298,7 +299,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static A makeLink(String text, String name, String value)
 	{
 
@@ -322,7 +322,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param text
 	 *            Description of the Parameter
 	 * @param name
@@ -331,7 +331,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static A makeLink(String text, String name, int value)
 	{
 
@@ -340,7 +339,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param text
 	 *            Description of the Parameter
 	 * @param name
@@ -349,7 +348,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static A makeLink(String text, String name, boolean value)
 	{
 
@@ -358,7 +356,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param text
 	 *            Description of the Parameter
 	 * @param clickAction
@@ -367,7 +365,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Input makeOnClickInput(String text, String clickAction, String type)
 	{
 
@@ -384,7 +381,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param labeltext
 	 *            Description of the Parameter
 	 * @param value
@@ -393,7 +390,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static TR makeOption(String labeltext, String value, Element e)
 	{
 
@@ -418,14 +414,13 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param label
 	 *            Description of the Parameter
 	 * @param value
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Option makeOption(String label, boolean value)
 	{
 
@@ -467,14 +462,13 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param name
 	 *            Description of the Parameter
 	 * @param options
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makePulldown(String name, List<String> options)
 	{
 
@@ -487,12 +481,12 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param results
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
+	 * @param name a {@link java.lang.String} object.
 	 */
-
 	public static Element makePulldown(String name, String results)
 	{
 
@@ -520,7 +514,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param name
 	 *            Description of the Parameter
 	 * @param list
@@ -531,7 +525,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Select makePulldown(String name, Object[] list, String selected, int rowsShowing)
 	{
 
@@ -562,10 +555,12 @@ public class ECSFactory
 
 	/**
 	 * Default size of 1 for rows showing in select box.
-	 * 
+	 *
 	 * @param diffNames
 	 *            Description of the Parameter
 	 * @param select
+	 *            Description of the Parameter
+	 * @param selected
 	 *            Description of the Parameter
 	 * @param name
 	 *            Description of the Parameter
@@ -577,7 +572,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makeSelect(boolean diffNames, Select select, String name, Vector<Option> options,
 			String[] list, String selected)
 	{
@@ -587,10 +581,12 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param diffNames
 	 *            Description of the Parameter
 	 * @param select
+	 *            Description of the Parameter
+	 * @param selected
 	 *            Description of the Parameter
 	 * @param name
 	 *            Description of the Parameter
@@ -604,7 +600,6 @@ public class ECSFactory
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Select makeSelect(boolean diffNames, Select select, String name, Vector<Option> options,
 			String[] list, String selected, int rowsShowing)
 	{
@@ -697,7 +692,7 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param title
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -715,14 +710,13 @@ public class ECSFactory
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param title
 	 *            Description of the Parameter
 	 * @param text
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
 	 */
-
 	public static Element makeTextArea(String title, String text)
 	{
 

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/Employee.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/Employee.java
@@ -4,32 +4,35 @@ package org.owasp.webgoat.session;
 import java.io.Serializable;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class Employee implements Serializable
 {
@@ -39,10 +42,13 @@ public class Employee implements Serializable
 	 */
 	private static final long serialVersionUID = -1901957360367218399L;
 
+	/** Constant <code>EMPLOYEE_ROLE="employee"</code> */
 	public final static String EMPLOYEE_ROLE = "employee";
 
+	/** Constant <code>MANAGER_ROLE="manager"</code> */
 	public final static String MANAGER_ROLE = "manager";
 
+	/** Constant <code>HR_ROLE="hr"</code> */
 	public final static String HR_ROLE = "hr";
 
 	private int id;
@@ -78,10 +84,33 @@ public class Employee implements Serializable
 	private String personalDescription;
 
 	// FIXME: To be deleted
+	/**
+	 * <p>Constructor for Employee.</p>
+	 */
 	public Employee()
 	{
 	}
 
+	/**
+	 * <p>Constructor for Employee.</p>
+	 *
+	 * @param id a int.
+	 * @param firstName a {@link java.lang.String} object.
+	 * @param lastName a {@link java.lang.String} object.
+	 * @param ssn a {@link java.lang.String} object.
+	 * @param title a {@link java.lang.String} object.
+	 * @param phone a {@link java.lang.String} object.
+	 * @param address1 a {@link java.lang.String} object.
+	 * @param address2 a {@link java.lang.String} object.
+	 * @param manager a int.
+	 * @param startDate a {@link java.lang.String} object.
+	 * @param salary a int.
+	 * @param ccn a {@link java.lang.String} object.
+	 * @param ccnLimit a int.
+	 * @param disciplinaryActionDate a {@link java.lang.String} object.
+	 * @param disciplinaryActionNotes a {@link java.lang.String} object.
+	 * @param personalDescription a {@link java.lang.String} object.
+	 */
 	public Employee(int id, String firstName, String lastName, String ssn, String title, String phone, String address1,
 			String address2, int manager, String startDate, int salary, String ccn, int ccnLimit,
 			String disciplinaryActionDate, String disciplinaryActionNotes, String personalDescription)
@@ -104,136 +133,271 @@ public class Employee implements Serializable
 		this.personalDescription = personalDescription;
 	}
 
+	/**
+	 * <p>Getter for the field <code>address1</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getAddress1()
 	{
 		return address1;
 	}
 
+	/**
+	 * <p>Setter for the field <code>address1</code>.</p>
+	 *
+	 * @param address1 a {@link java.lang.String} object.
+	 */
 	public void setAddress1(String address1)
 	{
 		this.address1 = address1;
 	}
 
+	/**
+	 * <p>Getter for the field <code>address2</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getAddress2()
 	{
 		return address2;
 	}
 
+	/**
+	 * <p>Setter for the field <code>address2</code>.</p>
+	 *
+	 * @param address2 a {@link java.lang.String} object.
+	 */
 	public void setAddress2(String address2)
 	{
 		this.address2 = address2;
 	}
 
+	/**
+	 * <p>Getter for the field <code>ccn</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getCcn()
 	{
 		return ccn;
 	}
 
+	/**
+	 * <p>Setter for the field <code>ccn</code>.</p>
+	 *
+	 * @param ccn a {@link java.lang.String} object.
+	 */
 	public void setCcn(String ccn)
 	{
 		this.ccn = ccn;
 	}
 
+	/**
+	 * <p>Getter for the field <code>ccnLimit</code>.</p>
+	 *
+	 * @return a int.
+	 */
 	public int getCcnLimit()
 	{
 		return ccnLimit;
 	}
 
+	/**
+	 * <p>Setter for the field <code>ccnLimit</code>.</p>
+	 *
+	 * @param ccnLimit a int.
+	 */
 	public void setCcnLimit(int ccnLimit)
 	{
 		this.ccnLimit = ccnLimit;
 	}
 
+	/**
+	 * <p>Getter for the field <code>firstName</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getFirstName()
 	{
 		return firstName;
 	}
 
+	/**
+	 * <p>Setter for the field <code>firstName</code>.</p>
+	 *
+	 * @param firstName a {@link java.lang.String} object.
+	 */
 	public void setFirstName(String firstName)
 	{
 		this.firstName = firstName;
 	}
 
+	/**
+	 * <p>Getter for the field <code>lastName</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getLastName()
 	{
 		return lastName;
 	}
 
+	/**
+	 * <p>Setter for the field <code>lastName</code>.</p>
+	 *
+	 * @param lastName a {@link java.lang.String} object.
+	 */
 	public void setLastName(String lastName)
 	{
 		this.lastName = lastName;
 	}
 
+	/**
+	 * <p>getPhoneNumber.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getPhoneNumber()
 	{
 		return phone;
 	}
 
+	/**
+	 * <p>setPhoneNumber.</p>
+	 *
+	 * @param phone a {@link java.lang.String} object.
+	 */
 	public void setPhoneNumber(String phone)
 	{
 		this.phone = phone;
 	}
 
+	/**
+	 * <p>Getter for the field <code>salary</code>.</p>
+	 *
+	 * @return a int.
+	 */
 	public int getSalary()
 	{
 		return salary;
 	}
 
+	/**
+	 * <p>Setter for the field <code>salary</code>.</p>
+	 *
+	 * @param salary a int.
+	 */
 	public void setSalary(int salary)
 	{
 		this.salary = salary;
 	}
 
+	/**
+	 * <p>Getter for the field <code>ssn</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getSsn()
 	{
 		return ssn;
 	}
 
+	/**
+	 * <p>Setter for the field <code>ssn</code>.</p>
+	 *
+	 * @param ssn a {@link java.lang.String} object.
+	 */
 	public void setSsn(String ssn)
 	{
 		this.ssn = ssn;
 	}
 
+	/**
+	 * <p>Getter for the field <code>startDate</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getStartDate()
 	{
 		return startDate;
 	}
 
+	/**
+	 * <p>Setter for the field <code>startDate</code>.</p>
+	 *
+	 * @param startDate a {@link java.lang.String} object.
+	 */
 	public void setStartDate(String startDate)
 	{
 		this.startDate = startDate;
 	}
 
+	/**
+	 * <p>Getter for the field <code>id</code>.</p>
+	 *
+	 * @return a int.
+	 */
 	public int getId()
 	{
 		return id;
 	}
 
+	/**
+	 * <p>Setter for the field <code>id</code>.</p>
+	 *
+	 * @param id a int.
+	 */
 	public void setId(int id)
 	{
 		this.id = id;
 	}
 
+	/**
+	 * <p>Getter for the field <code>title</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getTitle()
 	{
 		return this.title;
 	}
 
+	/**
+	 * <p>Getter for the field <code>manager</code>.</p>
+	 *
+	 * @return a int.
+	 */
 	public int getManager()
 	{
 		return this.manager;
 	}
 
+	/**
+	 * <p>Getter for the field <code>disciplinaryActionDate</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getDisciplinaryActionDate()
 	{
 		return this.disciplinaryActionDate;
 	}
 
+	/**
+	 * <p>Getter for the field <code>disciplinaryActionNotes</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getDisciplinaryActionNotes()
 	{
 		return this.disciplinaryActionNotes;
 	}
 
+	/**
+	 * <p>Getter for the field <code>personalDescription</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getPersonalDescription()
 	{
 		return this.personalDescription;

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/EmployeeStub.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/EmployeeStub.java
@@ -4,32 +4,35 @@ package org.owasp.webgoat.session;
 import java.io.Serializable;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class EmployeeStub implements Serializable
 {
@@ -47,11 +50,26 @@ public class EmployeeStub implements Serializable
 
 	private String role;
 
+	/**
+	 * <p>Constructor for EmployeeStub.</p>
+	 *
+	 * @param id a int.
+	 * @param firstName a {@link java.lang.String} object.
+	 * @param lastName a {@link java.lang.String} object.
+	 */
 	public EmployeeStub(int id, String firstName, String lastName)
 	{
 		this(id, firstName, lastName, Employee.EMPLOYEE_ROLE);
 	}
 
+	/**
+	 * <p>Constructor for EmployeeStub.</p>
+	 *
+	 * @param id a int.
+	 * @param firstName a {@link java.lang.String} object.
+	 * @param lastName a {@link java.lang.String} object.
+	 * @param role a {@link java.lang.String} object.
+	 */
 	public EmployeeStub(int id, String firstName, String lastName, String role)
 	{
 		this.id = id;
@@ -60,21 +78,41 @@ public class EmployeeStub implements Serializable
 		this.role = role;
 	}
 
+	/**
+	 * <p>Getter for the field <code>firstName</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getFirstName()
 	{
 		return firstName;
 	}
 
+	/**
+	 * <p>Getter for the field <code>id</code>.</p>
+	 *
+	 * @return a int.
+	 */
 	public int getId()
 	{
 		return id;
 	}
 
+	/**
+	 * <p>Getter for the field <code>lastName</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getLastName()
 	{
 		return lastName;
 	}
 
+	/**
+	 * <p>Getter for the field <code>role</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getRole()
 	{
 		return role;

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/ErrorScreen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/ErrorScreen.java
@@ -19,35 +19,37 @@ import org.apache.ecs.html.TR;
 import org.apache.ecs.html.Table;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created November 4, 2003
+ * @since November 4, 2003
+ * @version $Id: $Id
  */
 public class ErrorScreen extends Screen
 {
@@ -63,7 +65,7 @@ public class ErrorScreen extends Screen
 
 	/**
 	 * Constructor for the ErrorScreen object
-	 * 
+	 *
 	 * @param s
 	 *            Description of the Parameter
 	 * @param t
@@ -78,7 +80,7 @@ public class ErrorScreen extends Screen
 
 	/**
 	 * Constructor for the ErrorScreen object
-	 * 
+	 *
 	 * @param s
 	 *            Description of the Parameter
 	 * @param msg
@@ -91,6 +93,11 @@ public class ErrorScreen extends Screen
 		setup(s);
 	}
 
+	/**
+	 * <p>fixCurrentScreen.</p>
+	 *
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+	 */
 	public void fixCurrentScreen(WebSession s)
 	{
 		// So the user can't get stuck on the error screen, reset the
@@ -107,6 +114,11 @@ public class ErrorScreen extends Screen
 		}
 	}
 
+	/**
+	 * <p>setup.</p>
+	 *
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+	 */
 	public void setup(WebSession s)
 	{
 		// call createContent first so messages will go somewhere
@@ -124,6 +136,12 @@ public class ErrorScreen extends Screen
 		setContent(layout);
 	}
 
+	/**
+	 * <p>wrapForm.</p>
+	 *
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+	 * @return a {@link org.apache.ecs.Element} object.
+	 */
 	protected Element wrapForm(WebSession s)
 	{
 		if (s == null) { return new StringElement("Invalid Session"); }
@@ -140,11 +158,9 @@ public class ErrorScreen extends Screen
 	}
 
 	/**
+	 * {@inheritDoc}
+	 *
 	 * Description of the Method
-	 * 
-	 * @param s
-	 *            Description of the Parameter
-	 * @return Description of the Return Value
 	 */
 	protected Element createContent(WebSession s)
 	{
@@ -170,7 +186,7 @@ public class ErrorScreen extends Screen
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param s
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -184,7 +200,7 @@ public class ErrorScreen extends Screen
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param t
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -211,7 +227,7 @@ public class ErrorScreen extends Screen
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param t
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -233,7 +249,7 @@ public class ErrorScreen extends Screen
 
 	/**
 	 * Gets the stackTrace attribute of the ErrorScreen class
-	 * 
+	 *
 	 * @param t
 	 *            Description of the Parameter
 	 * @return The stackTrace value
@@ -249,7 +265,7 @@ public class ErrorScreen extends Screen
 
 	/**
 	 * Gets the title attribute of the ErrorScreen object
-	 * 
+	 *
 	 * @return The title value
 	 */
 	public String getTitle()
@@ -257,6 +273,11 @@ public class ErrorScreen extends Screen
 		return ("Error");
 	}
 
+	/**
+	 * <p>getRole.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getRole()
 	{
 		return AbstractLesson.USER_ROLE;

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/LessonSession.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/LessonSession.java
@@ -1,37 +1,39 @@
 
 package org.owasp.webgoat.session;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * Represents a virtual session for a lesson. Lesson-specific session data may be stored here.
- * 
+ *
  * @author David Anderson <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created January 19, 2006
+ * @since January 19, 2006
+ * @version $Id: $Id
  */
 public class LessonSession
 {
@@ -40,21 +42,41 @@ public class LessonSession
 
 	private String currentLessonScreen;
 
+	/**
+	 * <p>setAuthenticated.</p>
+	 *
+	 * @param isAuthenticated a boolean.
+	 */
 	public void setAuthenticated(boolean isAuthenticated)
 	{
 		this.isAuthenticated = isAuthenticated;
 	}
 
+	/**
+	 * <p>isAuthenticated.</p>
+	 *
+	 * @return a boolean.
+	 */
 	public boolean isAuthenticated()
 	{
 		return this.isAuthenticated;
 	}
 
+	/**
+	 * <p>Setter for the field <code>currentLessonScreen</code>.</p>
+	 *
+	 * @param currentLessonScreen a {@link java.lang.String} object.
+	 */
 	public void setCurrentLessonScreen(String currentLessonScreen)
 	{
 		this.currentLessonScreen = currentLessonScreen;
 	}
 
+	/**
+	 * <p>Getter for the field <code>currentLessonScreen</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getCurrentLessonScreen()
 	{
 		return this.currentLessonScreen;

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/LessonTracker.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/LessonTracker.java
@@ -7,35 +7,37 @@ import java.io.FileOutputStream;
 import java.util.Properties;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 29, 2003
+ * @since October 29, 2003
+ * @version $Id: $Id
  */
 public class LessonTracker
 {
@@ -62,7 +64,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the completed attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The completed value
 	 */
 	public boolean getCompleted()
@@ -72,7 +74,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the maxHintLevel attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The maxHintLevel value
 	 */
 	public int getMaxHintLevel()
@@ -82,7 +84,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the numVisits attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The numVisits value
 	 */
 	public int getNumVisits()
@@ -92,7 +94,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the viewedCookies attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The viewedCookies value
 	 */
 	public boolean getViewedCookies()
@@ -102,7 +104,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the viewedHtml attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The viewedHtml value
 	 */
 	public boolean getViewedHtml()
@@ -112,7 +114,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the viewedLessonPlan attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The viewedLessonPlan value
 	 */
 	public boolean getViewedLessonPlan()
@@ -122,7 +124,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the viewedParameters attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The viewedParameters value
 	 */
 	public boolean getViewedParameters()
@@ -132,7 +134,7 @@ public class LessonTracker
 
 	/**
 	 * Gets the viewedSource attribute of the LessonTracker object
-	 * 
+	 *
 	 * @return The viewedSource value
 	 */
 	public boolean getViewedSource()
@@ -140,6 +142,11 @@ public class LessonTracker
 		return viewedSource;
 	}
 
+	/**
+	 * <p>Getter for the field <code>viewedSolution</code>.</p>
+	 *
+	 * @return a boolean.
+	 */
 	public boolean getViewedSolution()
 	{
 		return viewedSource;
@@ -155,9 +162,10 @@ public class LessonTracker
 
 	/**
 	 * Sets the properties attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param props
 	 *            The new properties value
+	 * @param screen a {@link org.owasp.webgoat.session.Screen} object.
 	 */
 	protected void setProperties(Properties props, Screen screen)
 	{
@@ -171,6 +179,12 @@ public class LessonTracker
 		viewedSource = Boolean.valueOf(props.getProperty(screen.getTitle() + ".viewedSource", "false")).booleanValue();
 	}
 
+	/**
+	 * <p>getUserDir.</p>
+	 *
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+	 * @return a {@link java.lang.String} object.
+	 */
 	public static String getUserDir(WebSession s)
 	{
 		return s.getContext().getRealPath("users") + "/";
@@ -183,12 +197,15 @@ public class LessonTracker
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
+	 * @param screen
+	 *            Description of the Parameter
 	 * @param screen
 	 *            Description of the Parameter
 	 * @param s
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
+	 * @param user a {@link java.lang.String} object.
 	 */
 	public static LessonTracker load(WebSession s, String user, Screen screen)
 	{
@@ -229,7 +246,7 @@ public class LessonTracker
 
 	/**
 	 * Sets the completed attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param completed
 	 *            The new completed value
 	 */
@@ -240,7 +257,7 @@ public class LessonTracker
 
 	/**
 	 * Sets the maxHintLevel attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param maxHintLevel
 	 *            The new maxHintLevel value
 	 */
@@ -251,7 +268,7 @@ public class LessonTracker
 
 	/**
 	 * Sets the viewedCookies attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param viewedCookies
 	 *            The new viewedCookies value
 	 */
@@ -262,7 +279,7 @@ public class LessonTracker
 
 	/**
 	 * Sets the viewedHtml attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param viewedHtml
 	 *            The new viewedHtml value
 	 */
@@ -273,7 +290,7 @@ public class LessonTracker
 
 	/**
 	 * Sets the viewedLessonPlan attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param viewedLessonPlan
 	 *            The new viewedLessonPlan value
 	 */
@@ -284,7 +301,7 @@ public class LessonTracker
 
 	/**
 	 * Sets the viewedParameters attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param viewedParameters
 	 *            The new viewedParameters value
 	 */
@@ -295,7 +312,7 @@ public class LessonTracker
 
 	/**
 	 * Sets the viewedSource attribute of the LessonTracker object
-	 * 
+	 *
 	 * @param viewedSource
 	 *            The new viewedSource value
 	 */
@@ -306,9 +323,8 @@ public class LessonTracker
 
 	/**
 	 * Sets the viewedSource attribute of the LessonTracker object
-	 * 
-	 * @param viewedSource
-	 *            The new viewedSource value
+	 *
+	 * @param viewedSolution a boolean.
 	 */
 	public void setViewedSolution(boolean viewedSolution)
 	{
@@ -317,9 +333,10 @@ public class LessonTracker
 
 	/**
 	 * Allows the storing of properties for the logged in and a screen.
-	 * 
+	 *
 	 * @param s
 	 *            Description of the Parameter
+	 * @param screen a {@link org.owasp.webgoat.session.Screen} object.
 	 */
 	public void store(WebSession s, Screen screen)
 	{
@@ -328,9 +345,11 @@ public class LessonTracker
 
 	/**
 	 * Allows the storing of properties for a user and a screen.
-	 * 
+	 *
 	 * @param s
 	 *            Description of the Parameter
+	 * @param screen a {@link org.owasp.webgoat.session.Screen} object.
+	 * @param user a {@link java.lang.String} object.
 	 */
 	public void store(WebSession s, Screen screen, String user)
 	{
@@ -367,7 +386,7 @@ public class LessonTracker
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @return Description of the Return Value
 	 */
 	public String toString()
@@ -386,6 +405,8 @@ public class LessonTracker
 	}
 
 	/**
+	 * <p>Getter for the field <code>lessonProperties</code>.</p>
+	 *
 	 * @return Returns the lessonProperties.
 	 */
 	public Properties getLessonProperties()
@@ -394,6 +415,8 @@ public class LessonTracker
 	}
 
 	/**
+	 * <p>Setter for the field <code>lessonProperties</code>.</p>
+	 *
 	 * @param lessonProperties
 	 *            The lessonProperties to set.
 	 */

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/Parameter.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/Parameter.java
@@ -1,32 +1,35 @@
 
 package org.owasp.webgoat.session;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class Parameter implements Comparable
 {
@@ -35,23 +38,40 @@ public class Parameter implements Comparable
 
 	String value;
 
+	/**
+	 * <p>Constructor for Parameter.</p>
+	 *
+	 * @param name a {@link java.lang.String} object.
+	 * @param value a {@link java.lang.String} object.
+	 */
 	public Parameter(String name, String value)
 	{
 		this.name = name;
 		this.value = value;
 	}
 
+	/**
+	 * <p>Getter for the field <code>name</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getName()
 	{
 		return name;
 	}
 
+	/**
+	 * <p>Getter for the field <code>value</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getValue()
 	{
 		return value;
 	}
 
 	// @Override
+	/** {@inheritDoc} */
 	public boolean equals(Object obj)
 	{
 		if (obj instanceof Parameter)
@@ -63,17 +83,28 @@ public class Parameter implements Comparable
 	}
 
 	// @Override
+	/**
+	 * <p>hashCode.</p>
+	 *
+	 * @return a int.
+	 */
 	public int hashCode()
 	{
 		return toString().hashCode();
 	}
 
 	// @Override
+	/**
+	 * <p>toString.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String toString()
 	{
 		return (name + "=" + value);
 	}
 
+	/** {@inheritDoc} */
 	public int compareTo(Object o)
 	{
 		return toString().compareTo(o.toString());

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/ParameterNotFoundException.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/ParameterNotFoundException.java
@@ -1,34 +1,36 @@
 
 package org.owasp.webgoat.session;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
+ * @version $Id: $Id
  */
 public class ParameterNotFoundException extends Exception
 {
@@ -48,7 +50,7 @@ public class ParameterNotFoundException extends Exception
 
 	/**
 	 * Constructs a new ParameterNotFoundException with the specified detail message.
-	 * 
+	 *
 	 * @param s
 	 *            the detail message
 	 */

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/ParameterParser.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/ParameterParser.java
@@ -37,8 +37,8 @@ import org.owasp.webgoat.util.HtmlEncoder;
  *
  * For details, please see http://webgoat.github.io
  *
- * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect
- * Security</a>
+ * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
+ * @version $Id: $Id
  */
 public class ParameterParser {
 
@@ -87,6 +87,7 @@ public class ParameterParser {
      * @param name the parameter name
      * @return the parameter value as a boolean
      * @exception ParameterNotFoundException if the parameter was not found
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public boolean getBooleanParameter(String name) throws ParameterNotFoundException {
         return new Boolean(getStringParameter(name)).booleanValue();
@@ -132,6 +133,8 @@ public class ParameterParser {
      * @exception ParameterNotFoundException if the parameter was not found
      * @exception NumberFormatException if the parameter value could not be
      * converted to a byte
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws java.lang.NumberFormatException if any.
      */
     public byte getByteParameter(String name) throws ParameterNotFoundException, NumberFormatException {
         return Byte.parseByte(getStringParameter(name));
@@ -161,6 +164,7 @@ public class ParameterParser {
      * @return the parameter value as a char
      * @exception ParameterNotFoundException if the parameter was not found or
      * was the empty string
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public char getCharParameter(String name) throws ParameterNotFoundException {
         String param = getStringParameter(name);
@@ -193,6 +197,7 @@ public class ParameterParser {
      *
      * @param name Description of the Parameter
      * @return The classNameParameter value
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public String getClassNameParameter(String name) throws ParameterNotFoundException {
         String p = getStringParameter(name);
@@ -225,6 +230,8 @@ public class ParameterParser {
      * @exception ParameterNotFoundException if the parameter was not found
      * @exception NumberFormatException if the parameter could not be converted
      * to a double
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws java.lang.NumberFormatException if any.
      */
     public double getDoubleParameter(String name) throws ParameterNotFoundException, NumberFormatException {
         return new Double(getStringParameter(name)).doubleValue();
@@ -254,6 +261,8 @@ public class ParameterParser {
      * @exception ParameterNotFoundException if the parameter was not found
      * @exception NumberFormatException if the parameter could not be converted
      * to a float
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws java.lang.NumberFormatException if any.
      */
     public float getFloatParameter(String name) throws ParameterNotFoundException, NumberFormatException {
         return new Float(getStringParameter(name)).floatValue();
@@ -299,6 +308,7 @@ public class ParameterParser {
      * invalid
      * @exception ParameterNotFoundException if the parameter was not found or
      * was the empty string
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public String getIPParameter(String name) throws ParameterNotFoundException {
         boolean valid = true;
@@ -372,6 +382,8 @@ public class ParameterParser {
      * @exception ParameterNotFoundException if the parameter was not found
      * @exception NumberFormatException if the parameter could not be converted
      * to a int
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws java.lang.NumberFormatException if any.
      */
     public int getIntParameter(String name) throws ParameterNotFoundException, NumberFormatException {
         return Integer.parseInt(getStringParameter(name));
@@ -401,6 +413,8 @@ public class ParameterParser {
      * @exception ParameterNotFoundException if the parameter was not found
      * @exception NumberFormatException if the parameter could not be converted
      * to a long
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws java.lang.NumberFormatException if any.
      */
     public long getLongParameter(String name) throws ParameterNotFoundException, NumberFormatException {
         return Long.parseLong(getStringParameter(name));
@@ -498,6 +512,7 @@ public class ParameterParser {
      * @param name Description of the Parameter
      * @return The rawParameter value
      * @exception ParameterNotFoundException Description of the Exception
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public String getRawParameter(String name) throws ParameterNotFoundException {
         String[] values = request.getParameterValues(name);
@@ -519,6 +534,8 @@ public class ParameterParser {
      * @exception ParameterNotFoundException if the parameter was not found
      * @exception NumberFormatException if the parameter could not be converted
      * to a short
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws java.lang.NumberFormatException if any.
      */
     public short getShortParameter(String name) throws ParameterNotFoundException, NumberFormatException {
         return Short.parseShort(getStringParameter(name));
@@ -547,6 +564,7 @@ public class ParameterParser {
      * @return the parameter value as a String
      * @exception ParameterNotFoundException if the parameter was not found or
      * was the empty string
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public String getStringParameter(String name) throws ParameterNotFoundException {
         String[] values = request.getParameterValues(name);
@@ -603,12 +621,13 @@ public class ParameterParser {
 
     /**
      * Gets the parameter named 'next' following the parameter 'first'. Presumes
-     * the structure: first=firstvalue&next=nextValue
+     * the structure: first=firstvalue&amp;next=nextValue
      *
      * @param first Description of the Parameter
      * @param next Description of the Parameter
      * @return The subParameter value
      * @exception ParameterNotFoundException Description of the Exception
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public String getSubParameter(String first, String next) throws ParameterNotFoundException {
         String[] values = request.getParameterValues(first);
@@ -664,6 +683,7 @@ public class ParameterParser {
      *
      * @param name Description of the Parameter
      * @return The wordParameter value
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
      */
     public String getWordParameter(String name) throws ParameterNotFoundException {
         String p = getStringParameter(name);
@@ -734,6 +754,15 @@ public class ParameterParser {
         }
     }
 
+    /**
+     * <p>getStrictAlphaParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param maxLength a int.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getStrictAlphaParameter(String name, int maxLength) throws ParameterNotFoundException,
             ValidationException {
         String alphaRegEx = "^[a-zA-Z\\s]{0," + maxLength + "}$";
@@ -742,6 +771,15 @@ public class ParameterParser {
         return getRegexParameter(name, alphaPattern);
     }
 
+    /**
+     * <p>getStrictNumericParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param maxLength a int.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getStrictNumericParameter(String name, int maxLength) throws ParameterNotFoundException,
             ValidationException {
         String numericRegEx = "^\\d{0," + maxLength + "}$";
@@ -754,6 +792,14 @@ public class ParameterParser {
 
     private static final Pattern Ssnpattern = Pattern.compile(SSNREGEX);
 
+    /**
+     * <p>getSsnParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getSsnParameter(String name) throws ParameterNotFoundException, ValidationException {
         return getRegexParameter(name, Ssnpattern);
     }
@@ -767,6 +813,14 @@ public class ParameterParser {
 
     private static final Pattern Ccnpattern = Pattern.compile(CCNREGEX);
 
+    /**
+     * <p>getCcnParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getCcnParameter(String name) throws ParameterNotFoundException, ValidationException {
         return getRegexParameter(name, Ccnpattern);
     }
@@ -775,10 +829,26 @@ public class ParameterParser {
 
     private static final Pattern Zippattern = Pattern.compile(ZIPREGEX);
 
+    /**
+     * <p>getZipParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getZipParameter(String name) throws ParameterNotFoundException, ValidationException {
         return getZipParameter(name, null);
     }
 
+    /**
+     * <p>getZipParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param def a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getZipParameter(String name, String def) throws ValidationException {
         return getRegexParameter(name, def, Zippattern);
     }
@@ -789,10 +859,26 @@ public class ParameterParser {
     // private static final String PHONEREGEX = "^([\\-()+ 0-9x])+$";
     private static final Pattern phonepattern = Pattern.compile(PHONEREGEX);
 
+    /**
+     * <p>getPhoneParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getPhoneParameter(String name) throws ParameterNotFoundException, ValidationException {
         return getPhoneParameter(name, null);
     }
 
+    /**
+     * <p>getPhoneParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param def a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getPhoneParameter(String name, String def) throws ValidationException {
         return getRegexParameter(name, def, phonepattern);
     }
@@ -801,10 +887,26 @@ public class ParameterParser {
 
     private static final Pattern emailpattern = Pattern.compile(EMAILREGEX);
 
+    /**
+     * <p>getEMailParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getEMailParameter(String name) throws ParameterNotFoundException, ValidationException {
         return getEMailParameter(name, null);
     }
 
+    /**
+     * <p>getEMailParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param def a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getEMailParameter(String name, String def) throws ValidationException {
         return getRegexParameter(name, def, emailpattern);
     }
@@ -813,10 +915,26 @@ public class ParameterParser {
 
     private static final Pattern datepattern = Pattern.compile(DATEREGEX);
 
+    /**
+     * <p>getDateParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getDateParameter(String name) throws ParameterNotFoundException, ValidationException {
         return getDateParameter(name, null);
     }
 
+    /**
+     * <p>getDateParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param def a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getDateParameter(String name, String def) throws ValidationException {
         return getRegexParameter(name, def, datepattern);
     }
@@ -825,14 +943,36 @@ public class ParameterParser {
 
     private static final Pattern URLpattern = Pattern.compile(URLREGEX);
 
+    /**
+     * <p>getURLParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getURLParameter(String name) throws ParameterNotFoundException, ValidationException {
         return getURLParameter(name, null);
     }
 
+    /**
+     * <p>getURLParameter.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param def a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ValidationException if any.
+     */
     public String getURLParameter(String name, String def) throws ValidationException {
         return getRegexParameter(name, def, URLpattern);
     }
 
+    /**
+     * <p>htmlEncode.</p>
+     *
+     * @param s a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
     protected static String htmlEncode(String s) {
         return HtmlEncoder.encode(s);
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/RandomLessonTracker.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/RandomLessonTracker.java
@@ -6,6 +6,11 @@ import java.util.Map;
 import java.util.Properties;
 
 
+/**
+ * <p>RandomLessonTracker class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class RandomLessonTracker extends LessonTracker
 {
 
@@ -15,23 +20,44 @@ public class RandomLessonTracker extends LessonTracker
 
 	private Map<String, Boolean> completed = new HashMap<String, Boolean>();
 
+	/**
+	 * <p>Constructor for RandomLessonTracker.</p>
+	 *
+	 * @param stages an array of {@link java.lang.String} objects.
+	 */
 	public RandomLessonTracker(String[] stages)
 	{
 		if (stages == null) stages = new String[0];
 		this.stages = stages;
 	}
 
+	/**
+	 * <p>Setter for the field <code>stage</code>.</p>
+	 *
+	 * @param stage a {@link java.lang.String} object.
+	 */
 	public void setStage(String stage)
 	{
 		this.stage = stage;
 	}
 
+	/**
+	 * <p>Getter for the field <code>stage</code>.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String getStage()
 	{
 		if (this.stage == null && stages.length > 0) return stages[0];
 		return this.stage;
 	}
 
+	/**
+	 * <p>setStageComplete.</p>
+	 *
+	 * @param stage a {@link java.lang.String} object.
+	 * @param complete a boolean.
+	 */
 	public void setStageComplete(String stage, boolean complete)
 	{
 		completed.put(stage, Boolean.valueOf(complete));
@@ -40,6 +66,12 @@ public class RandomLessonTracker extends LessonTracker
 		if (i < stages.length - 1) setStage(stages[i + 1]);
 	}
 
+	/**
+	 * <p>getStageNumber.</p>
+	 *
+	 * @param stage a {@link java.lang.String} object.
+	 * @return a int.
+	 */
 	public int getStageNumber(String stage)
 	{
 		for (int i = 0; i < stages.length; i++)
@@ -47,12 +79,19 @@ public class RandomLessonTracker extends LessonTracker
 		return -1;
 	}
 
+	/**
+	 * <p>hasCompleted.</p>
+	 *
+	 * @param stage a {@link java.lang.String} object.
+	 * @return a boolean.
+	 */
 	public boolean hasCompleted(String stage)
 	{
 		Boolean complete = completed.get(stage);
 		return complete == null ? false : complete.booleanValue();
 	}
 
+	/** {@inheritDoc} */
 	@Override
 	public boolean getCompleted()
 	{
@@ -61,6 +100,7 @@ public class RandomLessonTracker extends LessonTracker
 		return true;
 	}
 
+	/** {@inheritDoc} */
 	@Override
 	public void setCompleted(boolean complete)
 	{
@@ -70,6 +110,7 @@ public class RandomLessonTracker extends LessonTracker
 		setStage(stages[0]);
 	}
 
+	/** {@inheritDoc} */
 	protected void setProperties(Properties props, Screen screen)
 	{
 		super.setProperties(props, screen);
@@ -84,6 +125,7 @@ public class RandomLessonTracker extends LessonTracker
 		setStage(props.getProperty(screen.getTitle() + ".stage"));
 	}
 
+	/** {@inheritDoc} */
 	public void store(WebSession s, Screen screen, String user)
 	{
 		for (int i = 0; i < stages.length; i++)
@@ -102,6 +144,11 @@ public class RandomLessonTracker extends LessonTracker
 		super.store(s, screen, user);
 	}
 
+	/**
+	 * <p>toString.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String toString()
 	{
 		StringBuffer buff = new StringBuffer();

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/Role.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/Role.java
@@ -1,12 +1,27 @@
 package org.owasp.webgoat.session;
 
+/**
+ * <p>Role class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class Role {
     private String rolename;
 
+    /**
+     * <p>Constructor for Role.</p>
+     *
+     * @param rolename a {@link java.lang.String} object.
+     */
     public Role(String rolename) {
         this.rolename = rolename;
     }
 
+    /**
+     * <p>Getter for the field <code>rolename</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getRolename() {
         return this.rolename;
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/Screen.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/Screen.java
@@ -42,7 +42,8 @@ import org.owasp.webgoat.lessons.AbstractLesson;
  *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect
  * Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public abstract class Screen {
 
@@ -69,6 +70,11 @@ public abstract class Screen {
     // will be stored in the internal database. The user will be able to hack
     // into the database and change their role. This will allow the user to
     // see the admin screens, once they figure out how to turn the admin switch on.
+    /**
+     * <p>getRole.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public abstract String getRole();
 
     /**
@@ -106,19 +112,33 @@ public abstract class Screen {
     /**
      * Gets the lessonTracker attribute of the AbstractLesson object
      *
-     * @param userName Description of the Parameter
      * @return The lessonTracker value
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
      */
     public LessonTracker getLessonTracker(WebSession s) {
         UserTracker userTracker = UserTracker.instance();
         return userTracker.getLessonTracker(s, this);
     }
 
+    /**
+     * <p>getLessonTracker.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param userNameOverride a {@link java.lang.String} object.
+     * @return a {@link org.owasp.webgoat.session.LessonTracker} object.
+     */
     public LessonTracker getLessonTracker(WebSession s, String userNameOverride) {
         UserTracker userTracker = UserTracker.instance();
         return userTracker.getLessonTracker(s, userNameOverride, this);
     }
 
+    /**
+     * <p>getLessonTracker.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @param lesson a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     * @return a {@link org.owasp.webgoat.session.LessonTracker} object.
+     */
     public LessonTracker getLessonTracker(WebSession s, AbstractLesson lesson) {
         UserTracker userTracker = UserTracker.instance();
         return userTracker.getLessonTracker(s, lesson);
@@ -131,6 +151,11 @@ public abstract class Screen {
      */
     public abstract String getTitle();
 
+    /**
+     * <p>Setter for the field <code>content</code>.</p>
+     *
+     * @param content a {@link org.apache.ecs.Element} object.
+     */
     protected void setContent(Element content) {
         this.content = content;
     }
@@ -145,10 +170,20 @@ public abstract class Screen {
         return new A("http://www.aspectsecurity.com/webgoat.html", logo);
     }
 
+    /**
+     * <p>getSponsor.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getSponsor() {
         return "Aspect Security";
     }
 
+    /**
+     * <p>getSponsorLogoResource.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getSponsorLogoResource() {
         return "images/aspectlogo-horizontal-small.jpg";
     }
@@ -178,6 +213,7 @@ public abstract class Screen {
     /**
      * Returns the content length of the the html.
      *
+     * @return a int.
      */
     public int getContentLength() {
         return getContent().length();
@@ -197,6 +233,11 @@ public abstract class Screen {
     }
 
     // hook all the links
+    /**
+     * <p>Getter for the field <code>content</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getContent() {
         //String makeAllAjax = "<script>goat.utils.makeFormsAjax();goat.utils.ajaxifyAttackHref();</script>";
         // need to do this here as some of the lessons render forms after submission of an ajax form

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/SequentialLessonTracker.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/SequentialLessonTracker.java
@@ -4,33 +4,55 @@ package org.owasp.webgoat.session;
 import java.util.Properties;
 
 
+/**
+ * <p>SequentialLessonTracker class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class SequentialLessonTracker extends LessonTracker
 {
 
 	private int currentStage = 1;
 
+	/**
+	 * <p>getStage.</p>
+	 *
+	 * @return a int.
+	 */
 	public int getStage()
 	{
 		return currentStage;
 	}
 
+	/**
+	 * <p>setStage.</p>
+	 *
+	 * @param stage a int.
+	 */
 	public void setStage(int stage)
 	{
 		currentStage = stage;
 	}
 
+	/** {@inheritDoc} */
 	protected void setProperties(Properties props, Screen screen)
 	{
 		super.setProperties(props, screen);
 		currentStage = Integer.parseInt(props.getProperty(screen.getTitle() + ".currentStage"));
 	}
 
+	/** {@inheritDoc} */
 	public void store(WebSession s, Screen screen, String user)
 	{
 		lessonProperties.setProperty(screen.getTitle() + ".currentStage", Integer.toString(currentStage));
 		super.store(s, screen, user);
 	}
 
+	/**
+	 * <p>toString.</p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String toString()
 	{
 		return super.toString() + "    - currentStage:....... " + currentStage + "\n";

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/UnauthenticatedException.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/UnauthenticatedException.java
@@ -1,32 +1,35 @@
 
 package org.owasp.webgoat.session;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class UnauthenticatedException extends Exception
 {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/UnauthorizedException.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/UnauthorizedException.java
@@ -1,32 +1,35 @@
 
 package org.owasp.webgoat.session;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class UnauthorizedException extends Exception
 {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/User.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/User.java
@@ -3,23 +3,48 @@ package org.owasp.webgoat.session;
 import java.util.ArrayList;
 import java.util.Iterator;
 
+/**
+ * <p>User class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class User {
     private String username;
     private ArrayList<Role> roles;
 
+    /**
+     * <p>Constructor for User.</p>
+     *
+     * @param username a {@link java.lang.String} object.
+     */
     public User(String username) {
         this.username = username;
         this.roles = new ArrayList<Role>();
     }
 
+    /**
+     * <p>Getter for the field <code>username</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getUsername() {
         return username;
     }
 
+    /**
+     * <p>Getter for the field <code>roles</code>.</p>
+     *
+     * @return a {@link java.util.Iterator} object.
+     */
     public Iterator<Role> getRoles() {
         return roles.iterator();
     }
 
+    /**
+     * <p>addRole.</p>
+     *
+     * @param rolename a {@link java.lang.String} object.
+     */
     public void addRole(String rolename) {
         roles.add(new Role(rolename));
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/UserDatabase.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/UserDatabase.java
@@ -23,6 +23,9 @@ class UserDatabase {
     private final String DELETE_ALL_ROLES_FOR_USER = "DELETE FROM user_roles WHERE user_id IN (SELECT id FROM users WHERE username = ?);";
     private final String DELETE_USER = "DELETE FROM users WHERE username = ?;";
 
+    /**
+     * <p>Constructor for UserDatabase.</p>
+     */
     public UserDatabase() {
         createDefaultTables();
         if (getTableCount("users") <= 0) {
@@ -36,6 +39,11 @@ class UserDatabase {
         }
     }
 
+    /**
+     * <p>open.</p>
+     *
+     * @return a boolean.
+     */
     public boolean open() {
         try {
             if (userDB == null || userDB.isClosed()) {
@@ -52,6 +60,11 @@ class UserDatabase {
         return true;
     }
 
+    /**
+     * <p>close.</p>
+     *
+     * @return a boolean.
+     */
     public boolean close() {
         try {
             if (userDB != null && !userDB.isClosed())
@@ -63,6 +76,12 @@ class UserDatabase {
         return true;
     }
 
+    /**
+     * <p>getTableCount.</p>
+     *
+     * @param tableName a {@link java.lang.String} object.
+     * @return a int.
+     */
     public int getTableCount(String tableName) {
         int count = 0;
         try {
@@ -82,6 +101,11 @@ class UserDatabase {
         return count;
     }
 
+    /**
+     * <p>getUsers.</p>
+     *
+     * @return a {@link java.util.Iterator} object.
+     */
     public Iterator<User> getUsers() {
         ArrayList<User> users = new ArrayList<User>();
         User currentUser;
@@ -113,6 +137,13 @@ class UserDatabase {
         return users.iterator();
     }
 
+    /**
+     * <p>addRoleToUser.</p>
+     *
+     * @param username a {@link java.lang.String} object.
+     * @param rolename a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public boolean addRoleToUser(String username, String rolename) {
         try {
             open();
@@ -129,10 +160,22 @@ class UserDatabase {
         return true;
     }
 
+    /**
+     * <p>removeUser.</p>
+     *
+     * @param user a {@link org.owasp.webgoat.session.User} object.
+     * @return a boolean.
+     */
     public boolean removeUser(User user) {
         return removeUser(user.getUsername());
     }
 
+    /**
+     * <p>removeUser.</p>
+     *
+     * @param username a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public boolean removeUser(String username) {
         try {
             open();

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/UserTracker.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/UserTracker.java
@@ -8,37 +8,38 @@ import java.util.Iterator;
 import java.util.Map;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- * @created October 29, 2003
+ * @since October 29, 2003
+ * @version $Id: $Id
  */
-
 public class UserTracker
 {
 
@@ -59,7 +60,7 @@ public class UserTracker
 
 	/**
 	 * Gets the completed attribute of the UserTracker object
-	 * 
+	 *
 	 * @param userName
 	 *            Description of the Parameter
 	 * @return The completed value
@@ -92,7 +93,7 @@ public class UserTracker
 
 	/**
 	 * Gets the users attribute of the UserTracker object
-	 * 
+	 *
 	 * @return The users value
 	 */
 	public Collection getUsers()
@@ -100,6 +101,12 @@ public class UserTracker
 		return storage.keySet();
 	}
 
+	/**
+	 * <p>getAllUsers.</p>
+	 *
+	 * @param roleName a {@link java.lang.String} object.
+	 * @return a {@link java.util.Collection} object.
+	 */
 	public Collection<String> getAllUsers(String roleName)
 	{
 		synchronized (usersDB)
@@ -130,6 +137,11 @@ public class UserTracker
 		}
 	}
 
+	/**
+	 * <p>deleteUser.</p>
+	 *
+	 * @param user a {@link java.lang.String} object.
+	 */
 	public void deleteUser(String user)
 	{
 		synchronized (usersDB)
@@ -158,18 +170,25 @@ public class UserTracker
 
 	/**
 	 * Gets the lessonTracker attribute of the UserTracker object
-	 * 
+	 *
 	 * @param screen
 	 *            Description of the Parameter
-	 * @param userName
-	 *            Description of the Parameter
 	 * @return The lessonTracker value
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
 	 */
 	public LessonTracker getLessonTracker(WebSession s, Screen screen)
 	{
 		return getLessonTracker(s, s.getUserName(), screen);
 	}
 
+	/**
+	 * <p>getLessonTracker.</p>
+	 *
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+	 * @param user a {@link java.lang.String} object.
+	 * @param screen a {@link org.owasp.webgoat.session.Screen} object.
+	 * @return a {@link org.owasp.webgoat.session.LessonTracker} object.
+	 */
 	public LessonTracker getLessonTracker(WebSession s, String user, Screen screen)
 	{
 		HashMap<String, LessonTracker> usermap = getUserMap(user);
@@ -187,12 +206,11 @@ public class UserTracker
 
 	/**
 	 * Gets the status attribute of the UserTracker object
-	 * 
+	 *
 	 * @param screen
 	 *            Description of the Parameter
-	 * @param userName
-	 *            Description of the Parameter
 	 * @return The status value
+	 * @param s a {@link org.owasp.webgoat.session.WebSession} object.
 	 */
 	public String getStatus(WebSession s, Screen screen)
 	{
@@ -228,7 +246,7 @@ public class UserTracker
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @return Description of the Return Value
 	 */
 	public static synchronized UserTracker instance()
@@ -246,7 +264,9 @@ public class UserTracker
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
+	 * @param screen
+	 *            Description of the Parameter
 	 * @param screen
 	 *            Description of the Parameter
 	 * @param s

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/ValidationException.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/ValidationException.java
@@ -1,32 +1,35 @@
 
 package org.owasp.webgoat.session;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class ValidationException extends Exception
 {
@@ -36,11 +39,19 @@ public class ValidationException extends Exception
 	 */
 	private static final long serialVersionUID = -8358754606830400708L;
 
+	/**
+	 * <p>Constructor for ValidationException.</p>
+	 */
 	public ValidationException()
 	{
 		super();
 	}
 
+	/**
+	 * <p>Constructor for ValidationException.</p>
+	 *
+	 * @param message a {@link java.lang.String} object.
+	 */
 	public ValidationException(String message)
 	{
 		super(message);

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/WebSession.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/WebSession.java
@@ -62,8 +62,8 @@ import org.slf4j.LoggerFactory;
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect
  * Security</a>
  * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
- *
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class WebSession {
 
@@ -94,6 +94,7 @@ public class WebSession {
      */
     public final static String COLOR = "color";
 
+    /** Constant <code>COURSE="course"</code> */
     public final static String COURSE = "course";
 
     /**
@@ -101,6 +102,7 @@ public class WebSession {
      */
     public final static int ERROR = 0;
 
+    /** Constant <code>STAGE="stage"</code> */
     public static final String STAGE = "stage";
 
     /**
@@ -133,28 +135,40 @@ public class WebSession {
      */
     public final static String SESSION = "websession";
 
+    /** Constant <code>SHOWSOURCE="ShowSource"</code> */
     public final static String SHOWSOURCE = "ShowSource";
 
+    /** Constant <code>SHOWSOLUTION="ShowSolution"</code> */
     public final static String SHOWSOLUTION = "ShowSolution";
 
+    /** Constant <code>SHOWHINTS="ShowHints"</code> */
     public final static String SHOWHINTS = "ShowHints";
 
+    /** Constant <code>SHOW="show"</code> */
     public final static String SHOW = "show";
 
+    /** Constant <code>SHOW_NEXTHINT="NextHint"</code> */
     public final static String SHOW_NEXTHINT = "NextHint";
 
+    /** Constant <code>SHOW_PREVIOUSHINT="PreviousHint"</code> */
     public final static String SHOW_PREVIOUSHINT = "PreviousHint";
 
+    /** Constant <code>SHOW_PARAMS="Params"</code> */
     public final static String SHOW_PARAMS = "Params";
 
+    /** Constant <code>SHOW_COOKIES="Cookies"</code> */
     public final static String SHOW_COOKIES = "Cookies";
 
+    /** Constant <code>SHOW_SOURCE="Source"</code> */
     public final static String SHOW_SOURCE = "Source";
 
+    /** Constant <code>SHOW_SOLUTION="Solution"</code> */
     public final static String SHOW_SOLUTION = "Solution";
 
+    /** Constant <code>DEBUG="debug"</code> */
     public final static String DEBUG = "debug";
 
+    /** Constant <code>LANGUAGE="language"</code> */
     public final static String LANGUAGE = "language";
 
     /**
@@ -221,7 +235,7 @@ public class WebSession {
     /**
      * Constructor for the WebSession object
      *
-     * @param webgoatContext
+     * @param webgoatContext a {@link org.owasp.webgoat.session.WebgoatContext} object.
      * @param context Description of the Parameter
      */
     public WebSession(WebgoatContext webgoatContext, ServletContext context) {
@@ -239,10 +253,22 @@ public class WebSession {
         course.loadCourses(webgoatContext, context, "/");
     }
 
+    /**
+     * <p>getConnection.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     * @return a {@link java.sql.Connection} object.
+     * @throws java.sql.SQLException if any.
+     */
     public static synchronized Connection getConnection(WebSession s) throws SQLException {
         return DatabaseUtilities.getConnection(s);
     }
 
+    /**
+     * <p>returnConnection.</p>
+     *
+     * @param s a {@link org.owasp.webgoat.session.WebSession} object.
+     */
     public static void returnConnection(WebSession s) {
         DatabaseUtilities.returnConnection(s.getUserName());
     }
@@ -297,6 +323,11 @@ public class WebSession {
         return context;
     }
 
+    /**
+     * <p>getRoles.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<String> getRoles() {
         List<String> roles = new ArrayList<String>();
 
@@ -315,13 +346,18 @@ public class WebSession {
      * This is also used by the WebSession to set the admin, but the method
      * should be private
      *
-     * @param state
+     * @param state a boolean.
      */
     public void setAdmin(boolean state) {
         isAdmin = state;
 
     }
 
+    /**
+     * <p>getRole.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getRole() {
 
         String role = "";
@@ -347,6 +383,11 @@ public class WebSession {
         return course;
     }
 
+    /**
+     * <p>Setter for the field <code>course</code>.</p>
+     *
+     * @param course a {@link org.owasp.webgoat.session.Course} object.
+     */
     public void setCourse(Course course) {
         this.course = course;
     }
@@ -360,14 +401,29 @@ public class WebSession {
         return (currentScreen);
     }
 
+    /**
+     * <p>Setter for the field <code>currentScreen</code>.</p>
+     *
+     * @param screen a int.
+     */
     public void setCurrentScreen(int screen) {
         currentScreen = screen;
     }
 
+    /**
+     * <p>getRestartLink.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getRestartLink() {
         return getCurrentLesson().getLink() + "&" + RESTART + "=" + getCurrentScreen();
     }
 
+    /**
+     * <p>getCurrentLink.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getCurrentLink() {
         String thisLink = "attack";
         Enumeration<String> e = request.getParameterNames();
@@ -386,14 +442,31 @@ public class WebSession {
         return thisLink;
     }
 
+    /**
+     * <p>getCurrentLesson.</p>
+     *
+     * @return a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     */
     public AbstractLesson getCurrentLesson() {
         return getCourse().getLesson(this, getCurrentScreen(), getRoles());
     }
 
+    /**
+     * <p>getLesson.</p>
+     *
+     * @param id a int.
+     * @return a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     */
     public AbstractLesson getLesson(int id) {
         return getCourse().getLesson(this, id, getRoles());
     }
 
+    /**
+     * <p>getLessons.</p>
+     *
+     * @param category a {@link org.owasp.webgoat.lessons.Category} object.
+     * @return a {@link java.util.List} object.
+     */
     public List<AbstractLesson> getLessons(Category category) {
         return getCourse().getLessons(this, category, getRoles());
     }
@@ -407,6 +480,11 @@ public class WebSession {
         return (hintNum);
     }
 
+    /**
+     * <p>getHint.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getHint() {
         String hint = null;
         int hints = getCurrentLesson().getHintCount(this);
@@ -421,6 +499,11 @@ public class WebSession {
         return hint;
     }
 
+    /**
+     * <p>getParams.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Parameter> getParams() {
         Vector<Parameter> params = null;
 
@@ -445,6 +528,11 @@ public class WebSession {
         return params;
     }
 
+    /**
+     * <p>getCookies.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Cookie> getCookies() {
         List<Cookie> cookies = null;
 
@@ -465,8 +553,8 @@ public class WebSession {
     /**
      * Gets the cookie attribute of the CookieScreen object
      *
-     * @param s Description of the Parameter
      * @return The cookie value
+     * @param cookieName a {@link java.lang.String} object.
      */
     public String getCookie(String cookieName) {
         Cookie[] cookies = getRequest().getCookies();
@@ -480,16 +568,31 @@ public class WebSession {
         return (null);
     }
 
+    /**
+     * <p>getSource.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getSource() {
         return "Sorry.  No Java Source viewing available.";
         // return getCurrentLesson().getSource(this);
     }
 
+    /**
+     * <p>getSolution.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getSolution() {
         return "Sorry.  No solution is available.";
         // return getCurrentLesson().getSolution(this);
     }
 
+    /**
+     * <p>getInstructions.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getInstructions() {
         return getCurrentLesson().getInstructions(this);
     }
@@ -530,6 +633,11 @@ public class WebSession {
         return request;
     }
 
+    /**
+     * <p>Setter for the field <code>request</code>.</p>
+     *
+     * @param request a {@link javax.servlet.http.HttpServletRequest} object.
+     */
     public void setRequest(HttpServletRequest request) {
         this.request = request;
     }
@@ -555,8 +663,8 @@ public class WebSession {
     /**
      * Gets the sourceFile attribute of the WebSession object
      *
-     * @param screen Description of the Parameter
      * @return The sourceFile value
+     * @param fileName a {@link java.lang.String} object.
      */
     public String getWebResource(String fileName) {
         // Note: doesn't work for admin path! Maybe with a ../ attack
@@ -601,6 +709,12 @@ public class WebSession {
 
     private Map<AbstractLesson, LessonSession> lessonSessions = new Hashtable<AbstractLesson, LessonSession>();
 
+    /**
+     * <p>isAuthenticatedInLesson.</p>
+     *
+     * @param lesson a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     * @return a boolean.
+     */
     public boolean isAuthenticatedInLesson(AbstractLesson lesson) {
         boolean authenticated = false;
 
@@ -613,32 +727,74 @@ public class WebSession {
         return authenticated;
     }
 
+    /**
+     * <p>isAuthorizedInLesson.</p>
+     *
+     * @param employeeId a int.
+     * @param functionId a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public boolean isAuthorizedInLesson(int employeeId, String functionId) {
         return getCurrentLesson().isAuthorized(this, employeeId, functionId);
     }
 
+    /**
+     * <p>isAuthorizedInLesson.</p>
+     *
+     * @param role a {@link java.lang.String} object.
+     * @param functionId a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public boolean isAuthorizedInLesson(String role, String functionId) {
         return getCurrentLesson().isAuthorized(this, role, functionId);
     }
 
+    /**
+     * <p>getUserIdInLesson.</p>
+     *
+     * @return a int.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     */
     public int getUserIdInLesson() throws ParameterNotFoundException {
         return getCurrentLesson().getUserId(this);
     }
 
+    /**
+     * <p>getUserNameInLesson.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     * @throws org.owasp.webgoat.session.ParameterNotFoundException if any.
+     */
     public String getUserNameInLesson() throws ParameterNotFoundException {
         return getCurrentLesson().getUserName(this);
     }
 
+    /**
+     * <p>openLessonSession.</p>
+     *
+     * @param lesson a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     */
     public void openLessonSession(AbstractLesson lesson) {
         System.out.println("Opening new lesson session for lesson " + lesson);
         LessonSession lessonSession = new LessonSession();
         lessonSessions.put(lesson, lessonSession);
     }
 
+    /**
+     * <p>closeLessonSession.</p>
+     *
+     * @param lesson a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     */
     public void closeLessonSession(AbstractLesson lesson) {
         lessonSessions.remove(lesson);
     }
 
+    /**
+     * <p>getLessonSession.</p>
+     *
+     * @param lesson a {@link org.owasp.webgoat.lessons.AbstractLesson} object.
+     * @return a {@link org.owasp.webgoat.session.LessonSession} object.
+     */
     public LessonSession getLessonSession(AbstractLesson lesson) {
         return lessonSessions.get(lesson);
     }
@@ -692,6 +848,11 @@ public class WebSession {
         message.append("<BR>" + " * " + text);
     }
 
+    /**
+     * <p>setLineBreak.</p>
+     *
+     * @param text a {@link java.lang.String} object.
+     */
     public void setLineBreak(String text) {
         message.append("<BR><BR>" + text);
     }
@@ -732,6 +893,11 @@ public class WebSession {
         return (showSource);
     }
 
+    /**
+     * <p>showSolution.</p>
+     *
+     * @return a boolean.
+     */
     public boolean showSolution() {
         return (showSolution);
     }
@@ -760,6 +926,7 @@ public class WebSession {
      * @param request Description of the Parameter
      * @param response Description of the Parameter
      * @param name Description of the Parameter
+     * @throws java.io.IOException if any.
      */
     public void update(HttpServletRequest request, HttpServletResponse response, String name) throws IOException {
         String content = null;
@@ -915,6 +1082,11 @@ public class WebSession {
         }
     }
 
+    /**
+     * <p>updateLastAttackRequestInfo.</p>
+     *
+     * @param request a {@link javax.servlet.http.HttpServletRequest} object.
+     */
     public void updateLastAttackRequestInfo(HttpServletRequest request) {
         // store cookies
         Cookie[] cookies = request.getCookies();
@@ -946,6 +1118,11 @@ public class WebSession {
         }
     }
 
+    /**
+     * <p>restartLesson.</p>
+     *
+     * @param lessonId a int.
+     */
     public void restartLesson(int lessonId) {
         AbstractLesson al = getLesson(lessonId);
         System.out.println("Restarting lesson: " + al);
@@ -960,7 +1137,9 @@ public class WebSession {
     }
 
     /**
-     * @param string
+     * <p>setHasHackableAdmin.</p>
+     *
+     * @param role a {@link java.lang.String} object.
      */
     public void setHasHackableAdmin(String role) {
         hasHackedHackableAdmin = (AbstractLesson.HACKED_ADMIN_ROLE.equals(role) & hasHackedHackableAdmin);
@@ -972,6 +1151,8 @@ public class WebSession {
     }
 
     /**
+     * <p>isDebug.</p>
+     *
      * @return Returns the isDebug.
      */
     public boolean isDebug() {
@@ -979,13 +1160,20 @@ public class WebSession {
     }
 
     /**
+     * <p>getHeader.</p>
+     *
      * @param header - request header value to return
-     * @return
+     * @return a {@link java.lang.String} object.
      */
     public String getHeader(String header) {
         return getRequest().getHeader(header);
     }
 
+    /**
+     * <p>getNextHint.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getNextHint() {
         String hint = null;
 
@@ -1003,6 +1191,11 @@ public class WebSession {
         return hint;
     }
 
+    /**
+     * <p>getPreviousHint.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getPreviousHint() {
         String hint = null;
 
@@ -1018,23 +1211,45 @@ public class WebSession {
         return hint;
     }
 
+    /**
+     * <p>Setter for the field <code>currentMenu</code>.</p>
+     *
+     * @param ranking a {@link java.lang.Integer} object.
+     */
     public void setCurrentMenu(Integer ranking) {
         currentMenu = ranking.intValue();
     }
 
+    /**
+     * <p>Getter for the field <code>currentMenu</code>.</p>
+     *
+     * @return a int.
+     */
     public int getCurrentMenu() {
         return currentMenu;
     }
 
+    /**
+     * <p>Getter for the field <code>webgoatContext</code>.</p>
+     *
+     * @return a {@link org.owasp.webgoat.session.WebgoatContext} object.
+     */
     public WebgoatContext getWebgoatContext() {
         return webgoatContext;
     }
 
+    /**
+     * <p>getCurrrentLanguage.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getCurrrentLanguage() {
         return currentLanguage;
     }
 
     /**
+     * <p>Getter for the field <code>cookiesOnLastRequest</code>.</p>
+     *
      * @return the cookiesOnLastRequest
      */
     public List<Cookie> getCookiesOnLastRequest() {
@@ -1042,6 +1257,8 @@ public class WebSession {
     }
 
     /**
+     * <p>Getter for the field <code>parmsOnLastRequest</code>.</p>
+     *
      * @return the parmsOnLastRequest
      */
     public List<RequestParameter> getParmsOnLastRequest() {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/WebgoatContext.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/WebgoatContext.java
@@ -5,42 +5,64 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServlet;
 
+/**
+ * <p>WebgoatContext class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class WebgoatContext {
 
     final Logger logger = LoggerFactory.getLogger(WebgoatContext.class);
 
+    /** Constant <code>DATABASE_CONNECTION_STRING="DatabaseConnectionString"</code> */
     public final static String DATABASE_CONNECTION_STRING = "DatabaseConnectionString";
 
+    /** Constant <code>DATABASE_DRIVER="DatabaseDriver"</code> */
     public final static String DATABASE_DRIVER = "DatabaseDriver";
 
+    /** Constant <code>DATABASE_USER="DatabaseUser"</code> */
     public final static String DATABASE_USER = "DatabaseUser";
 
+    /** Constant <code>DATABASE_PASSWORD="DatabasePassword"</code> */
     public final static String DATABASE_PASSWORD = "DatabasePassword";
 
+    /** Constant <code>ENTERPRISE="Enterprise"</code> */
     public final static String ENTERPRISE = "Enterprise";
 
+    /** Constant <code>CODING_EXERCISES="CodingExercises"</code> */
     public final static String CODING_EXERCISES = "CodingExercises";
 
+    /** Constant <code>SHOWCOOKIES="ShowCookies"</code> */
     public final static String SHOWCOOKIES = "ShowCookies";
 
+    /** Constant <code>SHOWPARAMS="ShowParams"</code> */
     public final static String SHOWPARAMS = "ShowParams";
 
+    /** Constant <code>SHOWREQUEST="ShowRequest"</code> */
     public final static String SHOWREQUEST = "ShowRequest";
 
+    /** Constant <code>SHOWSOURCE="ShowSource"</code> */
     public final static String SHOWSOURCE = "ShowSource";
 
+    /** Constant <code>SHOWSOLUTION="ShowSolution"</code> */
     public final static String SHOWSOLUTION = "ShowSolution";
 
+    /** Constant <code>SHOWHINTS="ShowHints"</code> */
     public final static String SHOWHINTS = "ShowHints";
 
+    /** Constant <code>DEFUSEOSCOMMANDS="DefuseOSCommands"</code> */
     public final static String DEFUSEOSCOMMANDS = "DefuseOSCommands";
 
+    /** Constant <code>FEEDBACK_ADDRESS_HTML="FeedbackAddressHTML"</code> */
     public final static String FEEDBACK_ADDRESS_HTML = "FeedbackAddressHTML";
 
+    /** Constant <code>FEEDBACK_ADDRESS="email"</code> */
     public final static String FEEDBACK_ADDRESS = "email";
 
+    /** Constant <code>DEBUG="debug"</code> */
     public final static String DEBUG = "debug";
 
+    /** Constant <code>DEFAULTLANGUAGE="DefaultLanguage"</code> */
     public final static String DEFAULTLANGUAGE = "DefaultLanguage";
 
     private String databaseConnectionString;
@@ -83,6 +105,11 @@ public class WebgoatContext {
 
     private java.nio.file.Path pluginDirectory;
 
+    /**
+     * <p>Constructor for WebgoatContext.</p>
+     *
+     * @param servlet a {@link javax.servlet.http.HttpServlet} object.
+     */
     public WebgoatContext(HttpServlet servlet) {
         this.servlet = servlet;
         databaseConnectionString = getParameter(servlet, DATABASE_CONNECTION_STRING);
@@ -164,54 +191,119 @@ public class WebgoatContext {
         return (databasePassword);
     }
 
+    /**
+     * <p>isDefuseOSCommands.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isDefuseOSCommands() {
         return defuseOSCommands;
     }
 
+    /**
+     * <p>isEnterprise.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isEnterprise() {
         return enterprise;
     }
 
+    /**
+     * <p>isCodingExercises.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isCodingExercises() {
         return codingExercises;
     }
 
+    /**
+     * <p>Getter for the field <code>feedbackAddress</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getFeedbackAddress() {
         return feedbackAddress;
     }
 
+    /**
+     * <p>Getter for the field <code>feedbackAddressHTML</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getFeedbackAddressHTML() {
         return feedbackAddressHTML;
     }
 
+    /**
+     * <p>isDebug.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isDebug() {
         return isDebug;
     }
 
+    /**
+     * <p>Getter for the field <code>servletName</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getServletName() {
         return servletName;
     }
 
+    /**
+     * <p>isShowCookies.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isShowCookies() {
         return showCookies;
     }
 
+    /**
+     * <p>isShowParams.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isShowParams() {
         return showParams;
     }
 
+    /**
+     * <p>isShowRequest.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isShowRequest() {
         return showRequest;
     }
 
+    /**
+     * <p>isShowSource.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isShowSource() {
         return showSource;
     }
 
+    /**
+     * <p>isShowSolution.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isShowSolution() {
         return showSolution;
     }
 
+    /**
+     * <p>Getter for the field <code>defaultLanguage</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDefaultLanguage() {
         return defaultLanguage;
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/WebgoatProperties.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/WebgoatProperties.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
  * for free software projects.
  *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class WebgoatProperties extends Properties {
 
@@ -46,6 +48,12 @@ public class WebgoatProperties extends Properties {
     private static final long serialVersionUID = 4351681705558227918L;
     final Logger logger = LoggerFactory.getLogger(WebgoatProperties.class);
 
+    /**
+     * <p>Constructor for WebgoatProperties.</p>
+     *
+     * @param propertiesFileName a {@link java.lang.String} object.
+     * @throws java.io.IOException if any.
+     */
     public WebgoatProperties(String propertiesFileName) throws IOException {
         if (propertiesFileName == null) {
             throw new IOException("Path to webgoat.properties is null, initialization must have failed");
@@ -58,6 +66,13 @@ public class WebgoatProperties extends Properties {
         load(in);
     }
 
+    /**
+     * <p>getIntProperty.</p>
+     *
+     * @param key a {@link java.lang.String} object.
+     * @param defaultValue a int.
+     * @return a int.
+     */
     public int getIntProperty(String key, int defaultValue) {
         int value = defaultValue;
 
@@ -69,6 +84,13 @@ public class WebgoatProperties extends Properties {
         return value;
     }
 
+    /**
+     * <p>getBooleanProperty.</p>
+     *
+     * @param key a {@link java.lang.String} object.
+     * @param defaultValue a boolean.
+     * @return a boolean.
+     */
     public boolean getBooleanProperty(String key, boolean defaultValue) {
         boolean value = defaultValue;
         key = this.trimLesson(key);
@@ -105,6 +127,11 @@ public class WebgoatProperties extends Properties {
         return result;
     }
 
+    /**
+     * <p>main.</p>
+     *
+     * @param args an array of {@link java.lang.String} objects.
+     */
     public static void main(String[] args) {
         WebgoatProperties properties = null;
         try {

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/BeanProvider.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/BeanProvider.java
@@ -7,38 +7,42 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for
  * free software projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 @Component
 public class BeanProvider implements ApplicationContextAware
 {
 	private static ApplicationContext ctx;
 
+	/** {@inheritDoc} */
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException
 	{
@@ -48,12 +52,13 @@ public class BeanProvider implements ApplicationContextAware
 
 	/**
 	 * Get access to managed beans from id.
-	 * 
+	 *
 	 * @param beanName
 	 *            the id of the searched bean
 	 * @param beanClass
 	 *            the type of tye searched bean
-	 * @return
+	 * @param <T> a T object.
+	 * @return a T object.
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> T getBean(final String beanName, final Class<T> beanClass)

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/Exec.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/Exec.java
@@ -9,42 +9,44 @@ import java.util.Arrays;
 import java.util.BitSet;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
- * @created October 28, 2003
+ * @since October 28, 2003
+ * @version $Id: $Id
  */
 public class Exec
 {
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @param input
@@ -58,7 +60,7 @@ public class Exec
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -78,7 +80,7 @@ public class Exec
 	 */
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @param input
@@ -260,7 +262,7 @@ public class Exec
 	 */
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @param input
@@ -434,7 +436,7 @@ public class Exec
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -446,7 +448,7 @@ public class Exec
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -458,7 +460,7 @@ public class Exec
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @param args
@@ -472,7 +474,7 @@ public class Exec
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @param timeout
@@ -486,7 +488,7 @@ public class Exec
 
 	/**
 	 * The main program for the Exec class
-	 * 
+	 *
 	 * @param args
 	 *            The command line arguments
 	 */

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/ExecResults.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/ExecResults.java
@@ -1,34 +1,36 @@
 
 package org.owasp.webgoat.util;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
+ * @version $Id: $Id
  */
 public class ExecResults
 {
@@ -67,7 +69,7 @@ public class ExecResults
 
 	/**
 	 * Constructor for the ExecResults object
-	 * 
+	 *
 	 * @param command
 	 *            Description of the Parameter
 	 * @param input
@@ -103,7 +105,7 @@ public class ExecResults
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param value
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -115,7 +117,7 @@ public class ExecResults
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param value
 	 *            Description of the Parameter
 	 * @param fromIndex
@@ -129,7 +131,7 @@ public class ExecResults
 
 	/**
 	 * Gets the error attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The error value
 	 */
 	public boolean getError()
@@ -139,7 +141,7 @@ public class ExecResults
 
 	/**
 	 * Gets the errorMessage attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The errorMessage value
 	 */
 	public String getErrorMessage()
@@ -159,7 +161,7 @@ public class ExecResults
 
 	/**
 	 * Gets the errorType attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The errorType value
 	 */
 	public int getErrorType()
@@ -169,7 +171,7 @@ public class ExecResults
 
 	/**
 	 * Gets the errors attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The errors value
 	 */
 	public String getErrors()
@@ -179,7 +181,7 @@ public class ExecResults
 
 	/**
 	 * Gets the interrupted attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The interrupted value
 	 */
 	public boolean getInterrupted()
@@ -189,7 +191,7 @@ public class ExecResults
 
 	/**
 	 * Gets the output attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The output value
 	 */
 	public String getOutput()
@@ -199,7 +201,7 @@ public class ExecResults
 
 	/**
 	 * Gets the returnCode attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The returnCode value
 	 */
 	public int getReturnCode()
@@ -209,7 +211,7 @@ public class ExecResults
 
 	/**
 	 * Gets the throwable attribute of the ExecResults object
-	 * 
+	 *
 	 * @return The throwable value
 	 */
 	public Throwable getThrowable()
@@ -219,7 +221,7 @@ public class ExecResults
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param value
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -231,7 +233,7 @@ public class ExecResults
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @param value
 	 *            Description of the Parameter
 	 * @param fromIndex
@@ -245,7 +247,7 @@ public class ExecResults
 
 	/**
 	 * Sets the error attribute of the ExecResults object
-	 * 
+	 *
 	 * @param value
 	 *            The new error value
 	 */
@@ -257,7 +259,7 @@ public class ExecResults
 
 	/**
 	 * Sets the errors attribute of the ExecResults object
-	 * 
+	 *
 	 * @param errors
 	 *            The new errors value
 	 */
@@ -276,7 +278,7 @@ public class ExecResults
 
 	/**
 	 * Sets the output attribute of the ExecResults object
-	 * 
+	 *
 	 * @param value
 	 *            The new output value
 	 */
@@ -287,7 +289,7 @@ public class ExecResults
 
 	/**
 	 * Sets the returnCode attribute of the ExecResults object
-	 * 
+	 *
 	 * @param value
 	 *            The new returnCode value
 	 */
@@ -298,7 +300,7 @@ public class ExecResults
 
 	/**
 	 * Sets the throwable attribute of the ExecResults object
-	 * 
+	 *
 	 * @param value
 	 *            The new throwable value
 	 */
@@ -310,7 +312,7 @@ public class ExecResults
 
 	/**
 	 * Description of the Method
-	 * 
+	 *
 	 * @return Description of the Return Value
 	 */
 	public String toString()

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/ExecutionException.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/ExecutionException.java
@@ -1,34 +1,36 @@
 
 package org.owasp.webgoat.util;
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author Jeff Williams <a href="http://www.aspectsecurity.com">Aspect Security</a>
+ * @version $Id: $Id
  */
 public class ExecutionException extends Exception
 {
@@ -48,7 +50,7 @@ public class ExecutionException extends Exception
 
 	/**
 	 * Constructor for the ExecutionException object
-	 * 
+	 *
 	 * @param msg
 	 *            Description of the Parameter
 	 */

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/HtmlEncoder.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/HtmlEncoder.java
@@ -5,32 +5,35 @@ import java.util.HashMap;
 import java.util.Map;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public class HtmlEncoder
 {
@@ -41,81 +44,84 @@ public class HtmlEncoder
 
 	// html entity list
 	private static Object[][] entities = { { "quot", new Integer(34) }, // " - double-quote
-			{ "amp", new Integer(38) }, // & - ampersand
-			{ "lt", new Integer(60) }, // < - less-than
-			{ "gt", new Integer(62) }, // > - greater-than
+			{ "amp", new Integer(38) }, //  - ampersand
+			{ "lt", new Integer(60) }, //  - less-than
+			{ "gt", new Integer(62) }, //  - greater-than
 			{ "nbsp", new Integer(160) }, // non-breaking space
-			{ "copy", new Integer(169) }, // © - copyright
-			{ "reg", new Integer(174) }, // ® - registered trademark
-			{ "Agrave", new Integer(192) }, // À - uppercase A, grave accent
-			{ "Aacute", new Integer(193) }, // Á - uppercase A, acute accent
-			{ "Acirc", new Integer(194) }, // Â - uppercase A, circumflex accent
-			{ "Atilde", new Integer(195) }, // Ã - uppercase A, tilde
-			{ "Auml", new Integer(196) }, // Ä - uppercase A, umlaut
-			{ "Aring", new Integer(197) }, // Å - uppercase A, ring
-			{ "AElig", new Integer(198) }, // Æ - uppercase AE
-			{ "Ccedil", new Integer(199) }, // Ç - uppercase C, cedilla
-			{ "Egrave", new Integer(200) }, // È - uppercase E, grave accent
-			{ "Eacute", new Integer(201) }, // É - uppercase E, acute accent
-			{ "Ecirc", new Integer(202) }, // Ê - uppercase E, circumflex accent
-			{ "Euml", new Integer(203) }, // Ë - uppercase E, umlaut
-			{ "Igrave", new Integer(204) }, // Ì - uppercase I, grave accent
-			{ "Iacute", new Integer(205) }, // Í - uppercase I, acute accent
-			{ "Icirc", new Integer(206) }, // Î - uppercase I, circumflex accent
-			{ "Iuml", new Integer(207) }, // Ï - uppercase I, umlaut
-			{ "ETH", new Integer(208) }, // Ð - uppercase Eth, Icelandic
-			{ "Ntilde", new Integer(209) }, // Ñ - uppercase N, tilde
-			{ "Ograve", new Integer(210) }, // Ò - uppercase O, grave accent
-			{ "Oacute", new Integer(211) }, // Ó - uppercase O, acute accent
-			{ "Ocirc", new Integer(212) }, // Ô - uppercase O, circumflex accent
-			{ "Otilde", new Integer(213) }, // Õ - uppercase O, tilde
-			{ "Ouml", new Integer(214) }, // Ö - uppercase O, umlaut
-			{ "Oslash", new Integer(216) }, // Ø - uppercase O, slash
-			{ "Ugrave", new Integer(217) }, // Ù - uppercase U, grave accent
-			{ "Uacute", new Integer(218) }, // Ú - uppercase U, acute accent
-			{ "Ucirc", new Integer(219) }, // Û - uppercase U, circumflex accent
-			{ "Uuml", new Integer(220) }, // Ü - uppercase U, umlaut
-			{ "Yacute", new Integer(221) }, // Ý - uppercase Y, acute accent
-			{ "THORN", new Integer(222) }, // Þ - uppercase THORN, Icelandic
-			{ "szlig", new Integer(223) }, // ß - lowercase sharps, German
-			{ "agrave", new Integer(224) }, // à - lowercase a, grave accent
-			{ "aacute", new Integer(225) }, // á - lowercase a, acute accent
-			{ "acirc", new Integer(226) }, // â - lowercase a, circumflex accent
-			{ "atilde", new Integer(227) }, // ã - lowercase a, tilde
-			{ "auml", new Integer(228) }, // ä - lowercase a, umlaut
-			{ "aring", new Integer(229) }, // å - lowercase a, ring
-			{ "aelig", new Integer(230) }, // æ - lowercase ae
-			{ "ccedil", new Integer(231) }, // ç - lowercase c, cedilla
-			{ "egrave", new Integer(232) }, // è - lowercase e, grave accent
-			{ "eacute", new Integer(233) }, // é - lowercase e, acute accent
-			{ "ecirc", new Integer(234) }, // ê - lowercase e, circumflex accent
-			{ "euml", new Integer(235) }, // ë - lowercase e, umlaut
-			{ "igrave", new Integer(236) }, // ì - lowercase i, grave accent
-			{ "iacute", new Integer(237) }, // í - lowercase i, acute accent
-			{ "icirc", new Integer(238) }, // î - lowercase i, circumflex accent
-			{ "iuml", new Integer(239) }, // ï - lowercase i, umlaut
-			{ "igrave", new Integer(236) }, // ì - lowercase i, grave accent
-			{ "iacute", new Integer(237) }, // í - lowercase i, acute accent
-			{ "icirc", new Integer(238) }, // î - lowercase i, circumflex accent
-			{ "iuml", new Integer(239) }, // ï - lowercase i, umlaut
-			{ "eth", new Integer(240) }, // ð - lowercase eth, Icelandic
-			{ "ntilde", new Integer(241) }, // ñ - lowercase n, tilde
-			{ "ograve", new Integer(242) }, // ò - lowercase o, grave accent
-			{ "oacute", new Integer(243) }, // ó - lowercase o, acute accent
-			{ "ocirc", new Integer(244) }, // ô - lowercase o, circumflex accent
-			{ "otilde", new Integer(245) }, // õ - lowercase o, tilde
-			{ "ouml", new Integer(246) }, // ö - lowercase o, umlaut
-			{ "oslash", new Integer(248) }, // ø - lowercase o, slash
-			{ "ugrave", new Integer(249) }, // ù - lowercase u, grave accent
-			{ "uacute", new Integer(250) }, // ú - lowercase u, acute accent
-			{ "ucirc", new Integer(251) }, // û - lowercase u, circumflex accent
-			{ "uuml", new Integer(252) }, // ü - lowercase u, umlaut
-			{ "yacute", new Integer(253) }, // ý - lowercase y, acute accent
-			{ "thorn", new Integer(254) }, // þ - lowercase thorn, Icelandic
-			{ "yuml", new Integer(255) }, // ÿ - lowercase y, umlaut
+			{ "copy", new Integer(169) }, //  - copyright
+			{ "reg", new Integer(174) }, // - registered trademark
+			{ "Agrave", new Integer(192) }, //  - uppercase A, grave accent
+			{ "Aacute", new Integer(193) }, //  - uppercase A, acute accent
+			{ "Acirc", new Integer(194) }, //  - uppercase A, circumflex accent
+			{ "Atilde", new Integer(195) }, //  - uppercase A, tilde
+			{ "Auml", new Integer(196) }, //  - uppercase A, umlaut
+			{ "Aring", new Integer(197) }, //  - uppercase A, ring
+			{ "AElig", new Integer(198) }, //  - uppercase AE
+			{ "Ccedil", new Integer(199) }, //  - uppercase C, cedilla
+			{ "Egrave", new Integer(200) }, //  - uppercase E, grave accent
+			{ "Eacute", new Integer(201) }, //  - uppercase E, acute accent
+			{ "Ecirc", new Integer(202) }, //  - uppercase E, circumflex accent
+			{ "Euml", new Integer(203) }, //  - uppercase E, umlaut
+			{ "Igrave", new Integer(204) }, //  - uppercase I, grave accent
+			{ "Iacute", new Integer(205) }, //  - uppercase I, acute accent
+			{ "Icirc", new Integer(206) }, //  - uppercase I, circumflex accent
+			{ "Iuml", new Integer(207) }, //  - uppercase I, umlaut
+			{ "ETH", new Integer(208) }, //  - uppercase Eth, Icelandic
+			{ "Ntilde", new Integer(209) }, //  - uppercase N, tilde
+			{ "Ograve", new Integer(210) }, //  - uppercase O, grave accent
+			{ "Oacute", new Integer(211) }, //  - uppercase O, acute accent
+			{ "Ocirc", new Integer(212) }, //  - uppercase O, circumflex accent
+			{ "Otilde", new Integer(213) }, //  - uppercase O, tilde
+			{ "Ouml", new Integer(214) }, //  - uppercase O, umlaut
+			{ "Oslash", new Integer(216) }, //  - uppercase O, slash
+			{ "Ugrave", new Integer(217) }, //  - uppercase U, grave accent
+			{ "Uacute", new Integer(218) }, //  - uppercase U, acute accent
+			{ "Ucirc", new Integer(219) }, //  - uppercase U, circumflex accent
+			{ "Uuml", new Integer(220) }, //  - uppercase U, umlaut
+			{ "Yacute", new Integer(221) }, //  - uppercase Y, acute accent
+			{ "THORN", new Integer(222) }, //  - uppercase THORN, Icelandic
+			{ "szlig", new Integer(223) }, //  - lowercase sharps, German
+			{ "agrave", new Integer(224) }, //  - lowercase a, grave accent
+			{ "aacute", new Integer(225) }, //  - lowercase a, acute accent
+			{ "acirc", new Integer(226) }, //  - lowercase a, circumflex accent
+			{ "atilde", new Integer(227) }, //  - lowercase a, tilde
+			{ "auml", new Integer(228) }, //  - lowercase a, umlaut
+			{ "aring", new Integer(229) }, //  - lowercase a, ring
+			{ "aelig", new Integer(230) }, //  - lowercase ae
+			{ "ccedil", new Integer(231) }, //  - lowercase c, cedilla
+			{ "egrave", new Integer(232) }, //  - lowercase e, grave accent
+			{ "eacute", new Integer(233) }, //  - lowercase e, acute accent
+			{ "ecirc", new Integer(234) }, //  - lowercase e, circumflex accent
+			{ "euml", new Integer(235) }, //  - lowercase e, umlaut
+			{ "igrave", new Integer(236) }, //  - lowercase i, grave accent
+			{ "iacute", new Integer(237) }, //  - lowercase i, acute accent
+			{ "icirc", new Integer(238) }, //  - lowercase i, circumflex accent
+			{ "iuml", new Integer(239) }, //  - lowercase i, umlaut
+			{ "igrave", new Integer(236) }, //  - lowercase i, grave accent
+			{ "iacute", new Integer(237) }, //  - lowercase i, acute accent
+			{ "icirc", new Integer(238) }, //  - lowercase i, circumflex accent
+			{ "iuml", new Integer(239) }, //  - lowercase i, umlaut
+			{ "eth", new Integer(240) }, //  - lowercase eth, Icelandic
+			{ "ntilde", new Integer(241) }, //  - lowercase n, tilde
+			{ "ograve", new Integer(242) }, //  - lowercase o, grave accent
+			{ "oacute", new Integer(243) }, //  - lowercase o, acute accent
+			{ "ocirc", new Integer(244) }, //  - lowercase o, circumflex accent
+			{ "otilde", new Integer(245) }, //  - lowercase o, tilde
+			{ "ouml", new Integer(246) }, //  - lowercase o, umlaut
+			{ "oslash", new Integer(248) }, //  - lowercase o, slash
+			{ "ugrave", new Integer(249) }, //  - lowercase u, grave accent
+			{ "uacute", new Integer(250) }, //  - lowercase u, acute accent
+			{ "ucirc", new Integer(251) }, //  - lowercase u, circumflex accent
+			{ "uuml", new Integer(252) }, //  - lowercase u, umlaut
+			{ "yacute", new Integer(253) }, //  - lowercase y, acute accent
+			{ "thorn", new Integer(254) }, //  - lowercase thorn, Icelandic
+			{ "yuml", new Integer(255) }, //  - lowercase y, umlaut
 			{ "euro", new Integer(8364) },// Euro symbol
 	};
 
+	/**
+	 * <p>Constructor for HtmlEncoder.</p>
+	 */
 	public HtmlEncoder()
 	{
 		for (int i = 0; i < entities.length; i++)
@@ -126,13 +132,12 @@ public class HtmlEncoder
 
 	/**
 	 * Turns funky characters into HTML entity equivalents
-	 * <p>
-	 * 
-	 * e.g. <tt>"bread" & "butter"</tt> => <tt>&amp;quot;bread&amp;quot; &amp;amp;
-	 *  &amp;quot;butter&amp;quot;</tt> . Update: supports nearly all HTML entities, including funky
+	 *
+	 * e.g. {@code "bread" & "butter"} = {@code &amp;quot;bread&amp;quot; &amp;amp;
+	 *  &amp;quot;butter&amp;quot;}. Update: supports nearly all HTML entities, including funky
 	 * accents. See the source code for more detail. Adapted from
 	 * http://www.purpletech.com/code/src/com/purpletech/util/Utils.java.
-	 * 
+	 *
 	 * @param s1
 	 *            Description of the Parameter
 	 * @return Description of the Return Value
@@ -172,7 +177,7 @@ public class HtmlEncoder
 	 * Given a string containing entity escapes, returns a string containing the actual Unicode
 	 * characters corresponding to the escapes. Adapted from
 	 * http://www.purpletech.com/code/src/com/purpletech/util/Utils.java.
-	 * 
+	 *
 	 * @param s1
 	 *            Description of the Parameter
 	 * @return Description of the Return Value

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/Interceptor.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/Interceptor.java
@@ -20,35 +20,36 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author sherif koussa - Macadamian Technologies
- * 
+ * @version $Id: $Id
  */
 public class Interceptor implements Filter
 {
@@ -61,12 +62,16 @@ public class Interceptor implements Filter
 	 * (non-Javadoc)
 	 * @see javax.servlet.Filter#destroy()
 	 */
+	/**
+	 * <p>destroy.</p>
+	 */
 	public void destroy()
 	{
 		// TODO Auto-generated method stub
 
 	}
 
+	/** {@inheritDoc} */
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
 			ServletException
 	{
@@ -134,6 +139,7 @@ public class Interceptor implements Filter
 	 * (non-Javadoc)
 	 * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)
 	 */
+	/** {@inheritDoc} */
 	public void init(FilterConfig arg0) throws ServletException
 	{
 		// TODO Auto-generated method stub

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelManager.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelManager.java
@@ -4,38 +4,52 @@ package org.owasp.webgoat.util;
 import java.util.Locale;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for
  * free software projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 public interface LabelManager
 {
 
+	/**
+	 * <p>setLocale.</p>
+	 *
+	 * @param locale a {@link java.util.Locale} object.
+	 */
 	public void setLocale(Locale locale);
 
+	/**
+	 * <p>get.</p>
+	 *
+	 * @param labelKey a {@link java.lang.String} object.
+	 * @return a {@link java.lang.String} object.
+	 */
 	public String get(String labelKey);
 
 }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelManagerImpl.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelManagerImpl.java
@@ -8,32 +8,35 @@ import java.io.Serializable;
 import java.util.Locale;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for
  * free software projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 @Component("labelManager")
 public class LabelManagerImpl implements LabelManager, Serializable
@@ -46,12 +49,21 @@ public class LabelManagerImpl implements LabelManager, Serializable
 	/** Locale mapped with current session. */
 	private Locale locale = new Locale(LabelProvider.DEFAULT_LANGUAGE);
 
+	/**
+	 * <p>Constructor for LabelManagerImpl.</p>
+	 */
 	protected LabelManagerImpl() {}
 
+	/**
+	 * <p>Constructor for LabelManagerImpl.</p>
+	 *
+	 * @param labelProvider a {@link org.owasp.webgoat.util.LabelProvider} object.
+	 */
 	protected LabelManagerImpl(LabelProvider labelProvider) {
 		this.labelProvider = labelProvider;
 	}
 
+	/** {@inheritDoc} */
 	public void setLocale(Locale locale)
 	{
 		if (locale != null)
@@ -60,6 +72,7 @@ public class LabelManagerImpl implements LabelManager, Serializable
 		}
 	}
 
+	/** {@inheritDoc} */
 	public String get(String labelKey)
 	{
 		return labelProvider.get(locale, labelKey);

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelProvider.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/LabelProvider.java
@@ -17,36 +17,41 @@ import java.util.Locale;
 
 
 /**
- * ************************************************************************************************
- * <p>
- * <p>
- * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
- * please see http://www.owasp.org/
- * <p>
+ * *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project
+ * utility. For details, please see http://www.owasp.org/
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * <p>
- * This program is free software; you can redistribute it and/or modify it under the terms of the
- * GNU General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
- * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License along with this program; if
- * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA.
- * <p>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
  * Getting Source ==============
- * <p>
- * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for
- * free software projects.
- * <p>
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
+ * for free software projects.
+ *
  * For details, please see http://webgoat.github.io
+ *
+ * @version $Id: $Id
  */
 @Component
 @Singleton
 public class LabelProvider {
+    /** Constant <code>DEFAULT_LANGUAGE="Locale.ENGLISH.getLanguage()"</code> */
     public final static String DEFAULT_LANGUAGE = Locale.ENGLISH.getLanguage();
 
     private static final List<Locale> SUPPORTED = Arrays.asList(Locale.GERMAN, Locale.FRENCH, Locale.ENGLISH,
@@ -54,6 +59,9 @@ public class LabelProvider {
     private final ReloadableResourceBundleMessageSource labels = new ReloadableResourceBundleMessageSource();
     private static final ReloadableResourceBundleMessageSource pluginLabels = new ReloadableResourceBundleMessageSource();
 
+    /**
+     * <p>Constructor for LabelProvider.</p>
+     */
     public LabelProvider() {
         labels.setBasename("classpath:/i18n/WebGoatLabels");
         labels.setFallbackToSystemLocale(false);
@@ -64,6 +72,11 @@ public class LabelProvider {
         });
     }
 
+    /**
+     * <p>updatePluginResources.</p>
+     *
+     * @param propertyFile a {@link java.nio.file.Path} object.
+     */
     public static void updatePluginResources(final Path propertyFile) {
         pluginLabels.setBasename("WebGoatLabels");
         pluginLabels.setFallbackToSystemLocale(false);
@@ -85,10 +98,20 @@ public class LabelProvider {
         });
     }
 
+    /**
+     * <p>refresh.</p>
+     */
     public static void refresh() {
         pluginLabels.clearCache();
     }
 
+    /**
+     * <p>get.</p>
+     *
+     * @param locale a {@link java.util.Locale} object.
+     * @param strName a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String get(Locale locale, String strName) {
         return pluginLabels.getMessage(strName, null, useLocaleOrFallbackToEnglish(locale));
     }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/ThreadWatcher.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/ThreadWatcher.java
@@ -4,35 +4,37 @@ package org.owasp.webgoat.util;
 import java.util.BitSet;
 
 
-/***************************************************************************************************
- * 
- * 
+/**
+ *************************************************************************************************
+ *
+ *
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
- * 
+ *
  * Copyright (c) 2002 - 20014 Bruce Mayhew
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with this program; if
  * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
- * 
+ *
  * Getting Source ==============
- * 
+ *
  * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
  * projects.
- * 
+ *
  * For details, please see http://webgoat.github.io
- * 
+ *
  * @author jwilliams@aspectsecurity.com
- * @created November 6, 2002
+ * @since November 6, 2002
+ * @version $Id: $Id
  */
 public class ThreadWatcher implements Runnable
 {
@@ -46,7 +48,7 @@ public class ThreadWatcher implements Runnable
 
 	/**
 	 * Constructor for the ThreadWatcher object
-	 * 
+	 *
 	 * @param p
 	 *            Description of the Parameter
 	 * @param interrupted

--- a/webgoat-container/src/main/java/org/owasp/webgoat/util/WebGoatI18N.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/util/WebGoatI18N.java
@@ -7,6 +7,11 @@ import java.util.ResourceBundle;
 import org.owasp.webgoat.session.WebgoatContext;
 
 @Deprecated
+/**
+ * <p>WebGoatI18N class.</p>
+ *
+ * @version $Id: $Id
+ */
 public class WebGoatI18N
 {
 
@@ -14,18 +19,33 @@ public class WebGoatI18N
 	private static Locale currentLocale;
 	private static WebGoatResourceBundleController localeController;
 	
+	/**
+	 * <p>Constructor for WebGoatI18N.</p>
+	 *
+	 * @param context a {@link org.owasp.webgoat.session.WebgoatContext} object.
+	 */
 	public WebGoatI18N(WebgoatContext context)
 	{
 		currentLocale = new Locale(context.getDefaultLanguage());
 		localeController = new WebGoatResourceBundleController(currentLocale);
 	}
 	
+	/**
+	 * <p>loadLanguage.</p>
+	 *
+	 * @param language a {@link java.lang.String} object.
+	 */
 	@Deprecated
 	public static void loadLanguage(String language)
 	{
 		// Do nothing
 	}
 	
+	/**
+	 * <p>Setter for the field <code>currentLocale</code>.</p>
+	 *
+	 * @param locale a {@link java.util.Locale} object.
+	 */
 	public static void setCurrentLocale(Locale locale)
 	{
 		if (!currentLocale.equals(locale))
@@ -39,6 +59,12 @@ public class WebGoatI18N
 		}
 	}
 
+	/**
+	 * <p>get.</p>
+	 *
+	 * @param strName a {@link java.lang.String} object.
+	 * @return a {@link java.lang.String} object.
+	 */
 	public static String get(String strName)
 	{
 		return labels.get(WebGoatI18N.currentLocale).getString(strName);

--- a/webgoat-container/src/main/resources/i18n/WebGoatLabels_en.properties
+++ b/webgoat-container/src/main/resources/i18n/WebGoatLabels_en.properties
@@ -1,0 +1,7 @@
+#General
+LessonCompleted=Congratulations. You have successfully completed this lesson.
+RestartLesson=Restart this Lesson
+SolutionVideos=Solution Videos
+ErrorGenerating=Error generating
+InvalidData=Invalid Data
+Go!=Go!


### PR DESCRIPTION
I know this PR is massive, but let me break down the changes:

1. In order to be release into Maven OSS/Central, we MUST provide javadocs and java sources. It is a requirement in order to release. So, all files that had missing or wrong javadocs strings have been updated with _javadocs only_.  __NO CODE WAS CHANGED DURING THE JAVADOCS WORK.__ Also worth mentioning that the new javadocs are "dummy stubs", and actual relevant information needs to be added to them, but at least this is a step in the right direction.

2. Since I had to update multiple information in the POMs to prepare for our Maven Central release, I went the extra mile and extracted all the dependencies version properties to the Parent Pom. This will make it easier to maintain plugins/dependency versions

3. Added a new "release" maven profile, which will be used only for our official releases.

4. Performed some work into the integration tests to support multiple browsers. As of now we will test against Chrome on Windows 7 and Firefox on linux. WIP to enable Safari and Edge browsers

5. Adding WebGoatLabels_en.properties to fix warning on ENGLISH locale.


6. __TODO FOR CONTRIBUTORS:__ Once this PR is merged, the contributors should but the information they want into the `<developer>` section of the `pom.xml`. My profile can serve as example
