### PR TITLE
Fix #112 deployment descriptor elements in wrong order 

### DIFF
--- a/webgoat-container/src/main/webapp/WEB-INF/web.xml
+++ b/webgoat-container/src/main/webapp/WEB-INF/web.xml
@@ -26,19 +26,19 @@
          parameters, including zero.
     -->
     <context-param>
-        <param-name>email</param-name>
-        <param-value>webgoat@owasp.org</param-value>
         <description>
             The EMAIL address of the administrator to whom questions
             and comments about this application should be addressed.
         </description>
+        <param-name>email</param-name>
+        <param-value>webgoat@owasp.org</param-value>
     </context-param>
     <context-param>
-         <param-name>emaillist</param-name>
-        <param-value>owasp-webgoat@lists.owasp.org</param-value>
         <description>
             The EMAIL address of the webgoat email list
         </description>
+        <param-name>emaillist</param-name>
+        <param-value>owasp-webgoat@lists.owasp.org</param-value>
     </context-param>
     <!-- spring MVC -->
     <context-param>
@@ -73,23 +73,23 @@
          You can define any number of servlets, including zero.
     -->
     <servlet>
-        <servlet-name>AxisServlet</servlet-name>
         <display-name>Apache-Axis Servlet</display-name>
+        <servlet-name>AxisServlet</servlet-name>
         <servlet-class>
           org.apache.axis.transport.http.AxisServlet
       </servlet-class>
     </servlet>
     <servlet>
-        <servlet-name>AdminServlet</servlet-name>
         <display-name>Axis Admin Servlet</display-name>
+        <servlet-name>AdminServlet</servlet-name>
         <servlet-class>
           org.apache.axis.transport.http.AdminServlet
       </servlet-class>
         <load-on-startup>100</load-on-startup>
     </servlet>
     <servlet>
-        <servlet-name>SOAPMonitorService</servlet-name>
         <display-name>SOAPMonitorService</display-name>
+        <servlet-name>SOAPMonitorService</servlet-name>
         <servlet-class>
           org.apache.axis.monitor.SOAPMonitorService
       </servlet-class>
@@ -100,7 +100,6 @@
         <load-on-startup>100</load-on-startup>
     </servlet>
     <servlet>
-        <servlet-name>WebGoat</servlet-name>
         <description>
         This servlet plays the "controller" role in the MVC architecture
         used in this application.
@@ -110,13 +109,14 @@
         filename extension is removed).  The corresponding value is the
         name of the action class that will be used to process this request.
       </description>
+        <servlet-name>WebGoat</servlet-name>
         <servlet-class>org.owasp.webgoat.HammerHead</servlet-class>
         <init-param>
-            <param-name>email</param-name>
-            <param-value>WebGoat@owasp.org</param-value>
             <description>The EMAIL address of the administrator to whom questions
         		and comments about this application should be addressed.
       		</description>
+            <param-name>email</param-name>
+            <param-value>WebGoat@owasp.org</param-value>
         </init-param>
         <init-param>
             <param-name>debug</param-name>
@@ -172,17 +172,17 @@
         <load-on-startup>5</load-on-startup>
     </servlet>
     <servlet>
-        <servlet-name>LessonSource</servlet-name>
         <description>
         This servlet returns the Java source of the current lesson. 
       </description>
+        <servlet-name>LessonSource</servlet-name>
         <servlet-class>org.owasp.webgoat.LessonSource</servlet-class>
     </servlet>
     <servlet>
-        <servlet-name>Catcher</servlet-name>
-        <description>
+	<description>
         This servlet catches any posts and marks the appropriate lesson property. 
       </description>
+        <servlet-name>Catcher</servlet-name>
         <servlet-class>org.owasp.webgoat.Catcher</servlet-class>
     </servlet>
     <servlet>


### PR DESCRIPTION
This commit changes the order of the elements in the deployment descriptor so that they validate according to the XSD in Eclipse.