### PR TITLE
Fix #81 to activate close button in the modal footer

### DIFF
--- a/webgoat-container/src/main/webapp/js/goatApp/view/UserAndInfoView.js
+++ b/webgoat-container/src/main/webapp/js/goatApp/view/UserAndInfoView.js
@@ -35,7 +35,7 @@ function($,
 
 		showAboutModal: function() {
 			$('#about-modal').show(400);
-			$('#about-modal div.modal-header button.close').unbind('click').on('click', function() {
+			$('#about-modal div.modal-header button.close, #about-modal div.modal-footer button').unbind('click').on('click', function() {
 				$('#about-modal').hide(200);
 			});
 		}


### PR DESCRIPTION
The button in the footer was not selected by the jQuery selector. This commit adds a second selector to activate the button in the modal footer. 

The second selector was added instead of selecting all buttons inside the modal in case there will be a future wish to add some button within the modal window itself.