### PR TITLE
Copy whole target folder, not just individual file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,10 @@ script:
   - cp -fa ./WebGoat-Lessons/target/plugins/*.jar ./webgoat-container/src/main/webapp/plugin_lessons/
   - if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then mvn -Prun-integration-tests clean install; else mvn clean install; fi
 before_deploy:
-  - export WEBGOAT_ARTIFACT_VERSION=$(grep "<version>" $HOME/build/$TRAVIS_REPO_SLUG/pom.xml | cut -d ">" -f 2 | cut -d "<" -f 1)
-  - export WEBGOAT_JAR_FILE=$HOME/build/$TRAVIS_REPO_SLUG/webgoat-container/target/webgoat-container-$WEBGOAT_ARTIFACT_VERSION.jar
-  - export WEBGOAT_JAR_EXEC_FILE=$HOME/build/$TRAVIS_REPO_SLUG/webgoat-container/target/webgoat-container-$WEBGOAT_ARTIFACT_VERSION-war-exec.jar
-  - export WEBGOAT_WAR_FILE=$HOME/build/$TRAVIS_REPO_SLUG/webgoat-container/target/webgoat-container-$WEBGOAT_ARTIFACT_VERSION.war
   - export WEBGOAT_CONTAINTER_TARGET_DIR=$HOME/build/$TRAVIS_REPO_SLUG/webgoat-container/target
   - export WEBGOAT_ARTIFACTS_FOLDER=$HOME/build/$TRAVIS_REPO_SLUG/Deployable_Artifacts/
   - mkdir $WEBGOAT_ARTIFACTS_FOLDER
-  - cp -fa $WEBGOAT_JAR_EXEC_FILE $WEBGOAT_ARTIFACTS_FOLDER
-  - cp -fa $WEBGOAT_JAR_FILE $WEBGOAT_ARTIFACTS_FOLDER
-  - cp -fa $WEBGOAT_WAR_FILE $WEBGOAT_ARTIFACTS_FOLDER
-  - cp -fa $WEBGOAT_CONTAINTER_TARGET_DIR/* $WEBGOAT_ARTIFACTS_FOLDER
+  - cp -fa $WEBGOAT_CONTAINTER_TARGET_DIR/* $WEBGOAT_ARTIFACTS_FOLDER/
   - echo "Contents of artifcts folder:"
   - ls $WEBGOAT_ARTIFACTS_FOLDER
 deploy:


### PR DESCRIPTION
Instead of copying jar/war artifact individually, copy the whole target folder to the "Deployable Artifacts", which will then be uploaded to Amazon S3

Signed-off-by: Doug Morato <dm@corp.io>