### PR TITLE
Test enable Coverity SAST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,9 @@ addons:
   coverity_scan:
     project:
       name: "WebGoat/WebGoat"
-      description: "Travis CI Build Automation"
+      description: "Coverity Scan from Travis CI Build Automation"
+    notification_email: doug.morato@owasp.org
     build_command_prepend: "mvn clean"
-    build_command:   "mvn -DskipTests=true install"
+    build_command: "mvn -DskipTests=true install"
+    branch_pattern: master
 


### PR DESCRIPTION
Coverity is a cloud static code analysis tool, free for open-source projects. Enable scan submissions from travis CI

Signed-off-by: Doug Morato <dm@corp.io>