### PR TITLE
Do not clean before mvn cobertura and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ deploy:
     jdk: oraclejdk8
 after_success:
   - mvn versioneye:update
-  - mvn clean cobertura:cobertura coveralls:report
+  - mvn cobertura:cobertura coveralls:report
 notifications:
   slack:
     secure: S9VFew5NSE8WDzYD1VDBUULKKT0fzgblQACznwQ85699b2yeX9TX58N3RZvRS1JVagVP1wu2xOrwN2g+AWx4Ro3UBZD5XG86uTJWpCLD4cRWHBoGMH2TfvI7/IzsWmgxH4MBxFRvZr/eEhlVAux+N9H4EoEdS4CKsJXEqV37PlA=


### PR DESCRIPTION
By cleaning before tbe cobertura goal, this was removing the exec.jar and the war file.

Signed-off-by: Doug Morato <dm@corp.io>