### PR TITLE
#66 Fixing jar plugin lifecycle issue

### DIFF
--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -119,7 +119,7 @@
                 <executions>
                     <execution>
                         <id>create-jar</id>
-                        <phase>compile</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>


### PR DESCRIPTION
The Eclipse import failed due to different that default lifecycle phase.