### PR TITLE
Setting GPG keyname as WebGoat in Parent Pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,9 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <keyname>WebGoat</keyname>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
In order to specify which key to use for signing the JAR/WAR, add the keyname configuration under the Release Profile on the Parent Pom

Signed-off-by: Doug Morato <dm@corp.io>