### PR TITLE
webgoat-container should unpack all the lessons #192

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,8 +195,36 @@
     <profiles>
         <profile>
             <id>release</id>
+			<dependencies>
+                <dependency>
+                    <groupId>org.owasp.webgoat.lesson</groupId>
+                    <artifactId>dist</artifactId>
+                    <version>1.0</version>
+                    <type>zip</type>
+                    <scope>provided</scope>
+                    <classifier>plugins</classifier>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
+				    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-lesson</id>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <outputDirectory>${project.basedir}/webgoat-container/src/main/webapp/plugin_lessons</outputDirectory>
+                                    <includeArtifactIds>dist</includeArtifactIds>
+                                    <includes>*.jar</includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
Fixed when `mvn -install` is executed in WebGoat-Lessons it will create a zip and upload it.
This project will unzip it during a `mvn -Prelease ........` and place the jars in the plugin_lessons directory.

This should automate the release process.