### PR TITLE
Enable weak authentication cookie lesson 

### DIFF
--- a/webgoat-container/src/main/webapp/WEB-INF/webgoat.properties
+++ b/webgoat-container/src/main/webapp/WEB-INF/webgoat.properties
@@ -13,7 +13,6 @@ lesson.HttpSplitting.hidden=true
 lesson.BasicAuthentication.hidden=true
 lesson.SameOriginPolicyProtection.hidden=true
 lesson.SilentTransactions.hidden=true
-lesson.WeakAuthenticationCookie.hidden=true
 lesson.TraceXSS.hidden=true
 lesson.DBSQLInjection.hidden=true
 lesson.DBCrossSiteScripting.hidden=true


### PR DESCRIPTION
Unable to reproduce the issue in #181 so this commit re-enables the lesson.