### PR TITLE
Fix shebang

### DIFF
--- a/webgoat_developer_bootstrap.sh
+++ b/webgoat_developer_bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Bootstrap the setup of WebGoat for developer use in Linux and Mac machines
 # This script will clone the necessary git repositories, call the maven goals


### PR DESCRIPTION
The code of the script uses bash syntax (e.g. [[  ]] tests) while the header refers to sh. For systems where sh is not a syslink to bash it's better to make the shabang explicit.

C.