### PR TITLE
Updates to Dev Bootstrap

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -95,7 +95,7 @@ launch Tomcat listening on localhost:8080
 mkdir WebGoat-Workspace
 cd WebGoat-Workspace
 curl -o webgoat_developer_bootstrap.sh https://raw.githubusercontent.com/WebGoat/WebGoat/master/webgoat_developer_bootstrap.sh
-sh webgoat_developer_bootstrap.sh
+./webgoat_developer_bootstrap.sh
 ```
 
 ## The Manual Way: Developer Edition!

--- a/webgoat_developer_bootstrap.sh
+++ b/webgoat_developer_bootstrap.sh
@@ -40,13 +40,13 @@ hr() {
             LINE="$LINE$WORD"
         done
 
-        echo "${LINE:0:$COLS}"
+        echo -e "${LINE:0:$COLS}"
     fi
 }
 
 ## test if command exists
 ftest() {
-  echo "$COL_CYAN  info: Checking if ${1} is installed $COL_RESET"
+  echo -e "$COL_CYAN  info: Checking if ${1} is installed $COL_RESET"
   if ! type -f "${1}" > /dev/null 2>&1; then
     return 1
   else
@@ -59,7 +59,7 @@ ftest() {
 features() {
   for f in "${@}"; do
     ftest "${f}" || {
-      echo >&2 "***$COL_RED ERROR: Missing \`${f}'! Make sure it exists and try again. $COL_RESET"
+      echo -e >&2 "***$COL_RED ERROR: Missing \`${f}'! Make sure it exists and try again. $COL_RESET"
       return 1
     }
   done
@@ -69,13 +69,13 @@ features() {
 tomcat_started () {
     STAT=`netstat -na | grep 8080 | awk '{print $6}'`
     if [ "$STAT" = "LISTEN" ]; then
-        echo "$COL_GREEN WebGoat has started successfully! Browse to the following address. $COL_RESET"
-        echo "$COL_CYAN Happy Hacking! $COL_RESET"
+        echo -e "$COL_GREEN WebGoat has started successfully! Browse to the following address. $COL_RESET"
+        echo -e "$COL_CYAN Happy Hacking! $COL_RESET"
         return 0
 
     elif [ "$STAT" = "" ]; then
-        echo "$COL_RED WebGoat failed to start up.... please wait run the following command for debugging : $COL_RESET"
-        echo "$COL_MAGENTA  mvn -q -file WebGoat/pom.xml -pl webgoat-container tomcat7:run-war"
+        echo -e "$COL_RED WebGoat failed to start up.... please wait run the following command for debugging : $COL_RESET"
+        echo -e "$COL_MAGENTA  mvn -q -file WebGoat/pom.xml -pl webgoat-container tomcat7:run-war"
     fi
     return 1
 }
@@ -84,7 +84,7 @@ tomcat_started () {
 ## main setup
 developer_bootstrap() {
     horizontal_rule
-    echo "$COL_RED
+    echo -e "$COL_RED
     ██╗    ██╗███████╗██████╗  ██████╗  ██████╗  █████╗ ████████╗
     ██║    ██║██╔════╝██╔══██╗██╔════╝ ██╔═══██╗██╔══██╗╚══██╔══╝
     ██║ █╗ ██║█████╗  ██████╔╝██║  ███╗██║   ██║███████║   ██║
@@ -93,23 +93,25 @@ developer_bootstrap() {
      ╚══╝╚══╝ ╚══════╝╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝   ╚═╝
     $COL_RESET"
     horizontal_rule
-    echo "Welcome to the WebGoat Developer Bootstrap script for Linux/Mac."
-    echo "Now checking if all the required software to run WebGoat is already installed."
-    echo "FYI: This Developer Bootstrap Script for WebGoat requires: Git, Java JDK and Maven accessible on the path"
+    echo -e "Welcome to the WebGoat Developer Bootstrap script for Linux/Mac."
+    echo -e "Now checking if all the required software to run WebGoat is already installed."
+    echo -e "FYI: This Developer Bootstrap Script for WebGoat requires: Git, Java JDK and Maven accessible on the path"
 
     ## test for require features
-    features git mvn java || return $?
+    features git mvn java 
+
+    return $1
 
     # Clone WebGoat from github
     if [ ! -d "WebGoat" ]; then
-        echo "Cloning the WebGoat container repository"
+        echo -e "Cloning the WebGoat container repository"
         git clone https://github.com/WebGoat/WebGoat.git
     else
         horizontal_rule
         (
-            echo "$COL_YELLOW The WebGoat container repo has already been clonned before, pulling upstream changes. $COL_RESET"
+            echo -e "$COL_YELLOW The WebGoat container repo has already been clonned before, pulling upstream changes. $COL_RESET"
             cd WebGoat || {
-                echo >&2 "$COL_RED *** ERROR: Could not cd into the WebGoat Directory. $COL_RESET"
+                echo -e >&2 "$COL_RED *** ERROR: Could not cd into the WebGoat Directory. $COL_RESET"
                 return 1
             }
             git pull origin master
@@ -119,14 +121,14 @@ developer_bootstrap() {
     # Clone WebGoat-lessons from GitHub if they don't exist
     if [ ! -d "WebGoat-Lessons" ]; then
         horizontal_rule
-        echo -e  "$COL_CYAN Cloning the WebGoat Lessons repository $COL_RESET"
+        echo -e -e  "$COL_CYAN Cloning the WebGoat Lessons repository $COL_RESET"
         git clone https://github.com/WebGoat/WebGoat-Lessons.git
     else
         horizontal_rule
         (
-            echo "$COL_YELLOW The WebGoat Lesson repo has already been cloned before, pulling upstream changes. $COL_RESET"
+            echo -e "$COL_YELLOW The WebGoat Lesson repo has already been cloned before, pulling upstream changes. $COL_RESET"
             cd WebGoat-Lessons || {
-                echo >&2 "$COL_RED *** ERROR: Could not cd into the WebGoat-Lessons Directory $COL_RESET"
+                echo -e >&2 "$COL_RED *** ERROR: Could not cd into the WebGoat-Lessons Directory $COL_RESET"
                 return 1
             }
             git pull origin master
@@ -135,47 +137,47 @@ developer_bootstrap() {
 
     # Compile and Install the WebGoat lesson server
     horizontal_rule
-    echo "$COL_BLUE Compiling and installing the WebGoat Container lesson server..... $COL_RESET"
+    echo -e "$COL_BLUE Compiling and installing the WebGoat Container lesson server..... $COL_RESET"
     mvn -q -DskipTests -file WebGoat/pom.xml clean compile install || {
-        echo >&2 "$COL_RED *** ERROR: Could not compile the WebGoat Container. $COL_RESET"
+        echo -e >&2 "$COL_RED *** ERROR: Could not compile the WebGoat Container. $COL_RESET"
         return 1
     }
-    echo "$COL_GREEN SUCCESS: Compiled the WebGoat Container successfully! $COL_RESET"
+    echo -e "$COL_GREEN SUCCESS: Compiled the WebGoat Container successfully! $COL_RESET"
 
     # Compile and package the WebGoat Lessons
     horizontal_rule
-    echo "$COL_BLUE Compiling and installing the WebGoat Lessons $COL_RESET"
+    echo -e "$COL_BLUE Compiling and installing the WebGoat Lessons $COL_RESET"
     mvn -q -DskipTests -file WebGoat-Lessons/pom.xml package || {
-        echo >&2 "$COL_RED *** ERROR: Could not compile the WebGoat Container. $COL_RESET"
+        echo -e >&2 "$COL_RED *** ERROR: Could not compile the WebGoat Container. $COL_RESET"
         return 1
     }
-    echo "$COL_GREEN SUCCESS: Compiled the WebGoat Lessons successfully! $COL_RESET"
+    echo -e "$COL_GREEN SUCCESS: Compiled the WebGoat Lessons successfully! $COL_RESET"
 
     # Copy the Lessons into the WebGoat-Container
     horizontal_rule
-    echo "$COL_BLUE Copying the compiled lessons jars into the container so we can start the lesson server with some base lessons, $COL_RESET"
+    echo -e "$COL_BLUE Copying the compiled lessons jars into the container so we can start the lesson server with some base lessons, $COL_RESET"
     cp -fa ./WebGoat-Lessons/target/plugins/*.jar ./WebGoat/webgoat-container/src/main/webapp/plugin_lessons/
 
     # Start the embedded Tomcat server
-    echo "$COL_MAGENTA"
+    echo -e "$COL_MAGENTA"
     horizontal_rule
     horizontal_rule
     horizontal_rule
     horizontal_rule
-    echo "$COL_MAGENTA"
-    echo "$COL_CYAN ***** Starting WebGoat using the embedded Tomcat ***** $COL_RESET"
-    echo " Please be patient.... The startup of the server can take from 30s to 3 minutes."
-    echo " WebGoat will be ready for you when you see the following message on the command prompt:"
-    echo "$COL_YELLOW INFO: Starting ProtocolHandler ["http-bio-8080"] $COL_RESET"
-    echo "$COL_CYAN When you see the message above, open a web browser and navigate to http://localhost:8080/WebGoat/ $COL_RESET"
-    echo " To stop the WebGoat and Tomcat Execution execution, press CTRL + C"
-    echo "$COL_RED If you close this terminal window, Tomcat and WebGoat will stop running $COL_RESET"
-    echo "$COL_MAGENTA"
+    echo -e "$COL_MAGENTA"
+    echo -e "$COL_CYAN ***** Starting WebGoat using the embedded Tomcat ***** $COL_RESET"
+    echo -e " Please be patient.... The startup of the server can take from 30s to 3 minutes."
+    echo -e " WebGoat will be ready for you when you see the following message on the command prompt:"
+    echo -e "$COL_YELLOW INFO: Starting ProtocolHandler ["http-bio-8080"] $COL_RESET"
+    echo -e "$COL_CYAN When you see the message above, open a web browser and navigate to http://localhost:8080/WebGoat/ $COL_RESET"
+    echo -e " To stop the WebGoat and Tomcat Execution execution, press CTRL + C"
+    echo -e "$COL_RED If you close this terminal window, Tomcat and WebGoat will stop running $COL_RESET"
+    echo -e "$COL_MAGENTA"
     horizontal_rule
     horizontal_rule
     horizontal_rule
     horizontal_rule
-    echo "$COL_RESET"
+    echo -e "$COL_RESET"
     sleep 5
 
     # Starting WebGoat


### PR DESCRIPTION
Commit Message:
- Use '-e' option in script echo commands to enable interpretation of escape sequences -> to make bash colours work
- README changed to show proper execution instruction

Script -> Bash colours aren't going to appear without '-e' option to interpret escape sequences.
README -> Can't rely on /bin/sh to symlink to /bin/bash, e.g. some distros will have it link to /bin/dash which doesn't accept -e as a echo option so the color output will fail. Either way, it's unnecessary as the script has the appropriate shebang declaration to be simply run with ./webgoat_developer_bootstrap.sh
