### PR TITLE
Issue #275: Activate Syntax Highlighting with Coderay in Asciidoc

### DIFF
--- a/webgoat-container/src/main/java/org/owasp/webgoat/AsciiDoctorTemplateResolver.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/AsciiDoctorTemplateResolver.java
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.asciidoctor.Asciidoctor.Factory.create;
@@ -83,7 +84,7 @@ public class AsciiDoctorTemplateResolver extends TemplateResolver {
                 if (adocFile.isPresent()) {
                     try (FileReader reader = new FileReader(adocFile.get().toFile())) {
                         StringWriter writer = new StringWriter();
-                        asciidoctor.convert(reader, writer, Maps.newHashMap());
+                        asciidoctor.convert(reader, writer, createAttributes());
                         return new ByteArrayInputStream(writer.getBuffer().toString().getBytes());
                     }
                 }
@@ -92,6 +93,16 @@ public class AsciiDoctorTemplateResolver extends TemplateResolver {
                 //no html yet
                 return new ByteArrayInputStream(new byte[0]);
             }
+        }
+
+        private Map<String, Object> createAttributes() {
+            Map<String, Object> attributes = Maps.newHashMap();
+            attributes.put("source-highlighter", "coderay");
+
+            Map<String, Object> options = Maps.newHashMap();
+            options.put("attributes", attributes);
+
+            return options;
         }
 
         private Optional<Path> find(Path path, String resourceName) throws IOException {

--- a/webgoat-container/src/main/resources/static/css/coderay.css
+++ b/webgoat-container/src/main/resources/static/css/coderay.css
@@ -1,0 +1,132 @@
+.CodeRay {
+  background-color: #efefef;
+  font-family: Monaco, "Courier New", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
+  color: #000;
+  margin-bottom: 14px;
+}
+
+.CodeRay pre {
+  margin: 0px;
+  padding: 1em;
+}
+
+div.CodeRay { }
+span.CodeRay { white-space: pre; border: 0px; padding: 2px }
+
+table.CodeRay { border-collapse: collapse; width: 100%; padding: 2px }
+table.CodeRay td {
+  padding: 1em 0.5em;
+  vertical-align: top;
+}
+
+.CodeRay .line-numbers, .CodeRay .no {
+  background-color: #ECECEC;
+  color: #AAA;
+  text-align: right;
+}
+
+.CodeRay .line-numbers a {
+  color: #AAA;
+}
+
+.CodeRay .line-numbers tt { font-weight: bold }
+.CodeRay .line-numbers .highlighted { color: red }
+.CodeRay .line { display: block; float: left; width: 100%; }
+.CodeRay span.line-numbers { padding: 0px 4px }
+.CodeRay .code { width: 100% }
+
+ol.CodeRay { font-size: 10pt }
+ol.CodeRay li { white-space: pre }
+
+.CodeRay .code pre { overflow: auto }
+.CodeRay .debug { color:white ! important; background:blue ! important; }
+
+.CodeRay .annotation { color:#007 }
+.CodeRay .attribute-name { color:#f08 }
+.CodeRay .attribute-value { color:#700 }
+.CodeRay .binary { color:#509; font-weight:bold }
+.CodeRay .comment  { color:#998; font-style: italic;}
+.CodeRay .char { color:#04D }
+.CodeRay .char .content { color:#04D }
+.CodeRay .char .delimiter { color:#039 }
+.CodeRay .class { color:#458; font-weight:bold }
+.CodeRay .complex { color:#A08; font-weight:bold }
+.CodeRay .constant { color:teal; }
+.CodeRay .color { color:#0A0 }
+.CodeRay .class-variable { color:#369 }
+.CodeRay .decorator { color:#B0B; }
+.CodeRay .definition { color:#099; font-weight:bold }
+.CodeRay .directive { color:#088; font-weight:bold }
+.CodeRay .delimiter { color:black }
+.CodeRay .doc { color:#970 }
+.CodeRay .doctype { color:#34b }
+.CodeRay .doc-string { color:#D42; font-weight:bold }
+.CodeRay .escape  { color:#666; font-weight:bold }
+.CodeRay .entity { color:#800; font-weight:bold }
+.CodeRay .error { color:#F00; background-color:#FAA }
+.CodeRay .exception { color:#C00; font-weight:bold }
+.CodeRay .filename { color:#099; }
+.CodeRay .function { color:#900; font-weight:bold }
+.CodeRay .global-variable { color:teal; font-weight:bold }
+.CodeRay .hex { color:#058; font-weight:bold }
+.CodeRay .integer  { color:#099; }
+.CodeRay .include { color:#B44; font-weight:bold }
+.CodeRay .inline { color: black }
+.CodeRay .inline .inline { background: #ccc }
+.CodeRay .inline .inline .inline { background: #bbb }
+.CodeRay .inline .inline-delimiter { color: #D14; }
+.CodeRay .inline-delimiter { color: #D14; }
+.CodeRay .important { color:#f00; }
+.CodeRay .interpreted { color:#B2B; font-weight:bold }
+.CodeRay .instance-variable { color:teal }
+.CodeRay .label { color:#970; font-weight:bold }
+.CodeRay .local-variable { color:#963 }
+.CodeRay .octal { color:#40E; font-weight:bold }
+.CodeRay .operator { }
+.CodeRay .predefined-constant {  font-weight:bold }
+.CodeRay .predefined { color:#369; font-weight:bold }
+.CodeRay .preprocessor { color:#579; }
+.CodeRay .pseudo-class { color:#00C; font-weight:bold }
+.CodeRay .predefined-type { color:#074; font-weight:bold }
+.CodeRay .reserved, .keyword  { color:#000; font-weight:bold }
+
+.CodeRay .key { color: #808; }
+.CodeRay .key .delimiter { color: #606; }
+.CodeRay .key .char { color: #80f; }
+.CodeRay .value { color: #088; }
+
+.CodeRay .regexp { background-color:#fff0ff }
+.CodeRay .regexp .content { color:#808 }
+.CodeRay .regexp .delimiter { color:#404 }
+.CodeRay .regexp .modifier { color:#C2C }
+.CodeRay .regexp .function  { color:#404; font-weight: bold }
+
+.CodeRay .string { color: #D20; }
+.CodeRay .string .string { }
+.CodeRay .string .string .string { background-color:#ffd0d0 }
+.CodeRay .string .content { color: #D14; }
+.CodeRay .string .char { color: #D14; }
+.CodeRay .string .delimiter { color: #D14; }
+
+.CodeRay .shell { color:#D14 }
+.CodeRay .shell .content { }
+.CodeRay .shell .delimiter { color:#D14 }
+
+.CodeRay .symbol { color:#990073 }
+.CodeRay .symbol .content { color:#A60 }
+.CodeRay .symbol .delimiter { color:#630 }
+
+.CodeRay .tag { color:#070 }
+.CodeRay .tag-special { color:#D70; font-weight:bold }
+.CodeRay .type { color:#339; font-weight:bold }
+.CodeRay .variable  { color:#036 }
+
+.CodeRay .insert { background: #afa; }
+.CodeRay .delete { background: #faa; }
+.CodeRay .change { color: #aaf; background: #007; }
+.CodeRay .head { color: #f8f; background: #505 }
+
+.CodeRay .insert .insert { color: #080; font-weight:bold }
+.CodeRay .delete .delete { color: #800; font-weight:bold }
+.CodeRay .change .change { color: #66f; }
+.CodeRay .head .head { color: #f4f; }

--- a/webgoat-container/src/main/resources/templates/main_new.html
+++ b/webgoat-container/src/main/resources/templates/main_new.html
@@ -21,6 +21,7 @@
     <link rel="stylesheet" type="text/css" th:href="@{/plugins/bootstrap/css/bootstrap.min.css}"/>
     <link rel="stylesheet" type="text/css" th:href="@{/css/font-awesome.min.css}"/>
     <link rel="stylesheet" type="text/css" th:href="@{/css/animate.css}"/>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/coderay.css}"/>
     <!--  end of CSS -->
 
     <!-- JS -->

--- a/webgoat-lessons/sql-injection/src/main/resources/plugin/SqlInjection/lessonPlans/en/SqlInjection_content9.adoc
+++ b/webgoat-lessons/sql-injection/src/main/resources/plugin/SqlInjection/lessonPlans/en/SqlInjection_content9.adoc
@@ -2,7 +2,7 @@
 [source,java]
 ----
 public static bool isUsernameValid(string username) {
-    RegEx r = new Regex(“^[A-Za-z0-9]{16}$”);
+    RegEx r = new Regex("^[A-Za-z0-9]{16}$");
     return r.isMatch(username); 
 }
 
@@ -10,10 +10,10 @@ public static bool isUsernameValid(string username) {
 PreparedStatement ps = null;
 RecordSet rs = null;
 try {
-    pUserName = request.getParameter(“UserName”);
+    pUserName = request.getParameter("UserName");
     if ( isUsernameValid (pUsername);
-        ps = conn.prepareStatement(“SELECT * FROM user_table 
-                                   WHERE username = ? ”);
+        ps = conn.prepareStatement("SELECT * FROM user_table 
+                                   WHERE username = ? ");
         ps.setString(1, pUsername);
         rs = ps.execute();
         if ( rs.next() ) {


### PR DESCRIPTION
Fixes #275 

This PR activates `source-highlighting` with **coderay**, which is the standard in **asciidoctorj**.

Depending on which one gets merged first, there might be a merge-conflict between this and #294, as they both introduce attributes for the `AsciiDoctorTemplateResolver`.

So now if you use `[source,java]` for a code-snippet in a `.adoc` template, it should be syntax-highlighted.

The snippet in the issue works now, I only had to switch the quotes, because they were somehow invalid:
![screen shot 2016-12-15 at 17 30 45](https://cloud.githubusercontent.com/assets/942652/21232864/7309c57a-c2ed-11e6-8646-a54f7c8c3e07.png)
