### PR TITLE
Issue #302: Fix redundant calls to lessonoverview.mvc and lessonmenu.…

### DIFF
--- a/webgoat-container/src/main/resources/static/js/goatApp/controller/LessonController.js
+++ b/webgoat-container/src/main/resources/static/js/goatApp/controller/LessonController.js
@@ -64,6 +64,8 @@ define(['jquery',
                 this.listenTo(this.lessonContent,'content:loaded',this.onContentLoaded);
                 this.userAndInfoView = new UserAndInfoView();
                 this.menuButtonView = new MenuButtonView();
+                this.listenTo(this.lessonContentView, 'lesson:complete', this.updateMenu);
+                this.listenTo(this.lessonContentView, 'lesson:complete', this.updateLessonOverview);
             };
 
             this.loadLesson = function(name,pageNum) {
@@ -104,8 +106,6 @@ define(['jquery',
                 this.listenTo(this.helpControlsView,'source:show',this.hideShowHelps);
                 this.listenTo(this.helpControlsView,'lesson:restart',this.restartLesson);
                 this.listenTo(this.developerControlsView, 'dev:labels', this.restartLesson);
-                this.listenTo(this.lessonContentView, 'lesson:complete', this.updateMenu)
-                this.listenTo(this.lessonContentView, 'lesson:complete', this.updateLessonOverview)
                 this.listenTo(this,'hints:show',this.onShowHints);
 
                 this.helpControlsView.render();


### PR DESCRIPTION
**Fixes #302:**

The problem was that the event listeners for `lesson:complete` where set every time a different lesson was selected (`this.onInfoLoaded`), so the more you navigated around, the more calls happened on submission.

I moved the `listenTo` calls to the `start` function, where they are only called once.

There are some other events being set in `this.onInfoLoaded`, but I wasn't sure which ones where safe to move somewhere else, but it's possible that they suffer from the same problem.

Now each call only happens once:
![screen shot 2017-01-07 at 15 43 37](https://cloud.githubusercontent.com/assets/942652/21742498/90f0e5ea-d4f0-11e6-9deb-beb304c85566.png)
![screen shot 2017-01-07 at 15 43 57](https://cloud.githubusercontent.com/assets/942652/21742499/910cdf0c-d4f0-11e6-9cb9-0e5f883d370a.png)
