### PR TITLE
Added support to build an Docker container to run it on Raspberry Pi

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -93,13 +93,42 @@ The source code will be available in the home directory.
 
 # Building a new Docker image
 
-WebGoat now has Docker support you can build a container with the following commands:
+WebGoat now has Docker support for x86 and arm (raspberry pi).
+### Docker on x86
+On x86 you can build a container with the following commands:
 
 ```Shell
 cd WebGoat/
 mvn package
 cd webgoat-container
+mvn package
 mvn docker:build
+docker tag webgoat/webgoat-8.0 webgoat/webgoat-8.0:8.0
+docker login
+docker push webgoat/webgoat-container
+```
+
+### Docker on ARM (Raspberry Pi)
+On a Raspberry Pi (it has yet been tested with a Raspberry Pi 3 and the hypriot Docker image) you need to build JFFI for 
+ARM first. This is needed by the docker-maven-plugin ([see here](https://github.com/spotify/docker-maven-plugin/issues/233)):
+
+```Shell
+sudo apt-get install build-essential
+git clone https://github.com/jnr/jffi.git
+cd jffi
+ant jar
+cd build/jni
+sudo cp libjffi-1.2.so /usr/lib
+```
+
+When you have done this you can build the Docker container using the following commands:
+ 
+```Shell
+cd WebGoat/
+mvn package
+cd webgoat-container
+mvn package
+mvn docker:build -Drpi=true
 docker tag webgoat/webgoat-8.0 webgoat/webgoat-8.0:8.0
 docker login
 docker push webgoat/webgoat-container

--- a/README.MD
+++ b/README.MD
@@ -93,7 +93,7 @@ The source code will be available in the home directory.
 
 # Building a new Docker image
 
-WebGoat now has Docker support for x86 and arm (raspberry pi).
+WebGoat now has Docker support for x86 and ARM (raspberry pi).
 ### Docker on x86
 On x86 you can build a container with the following commands:
 

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -21,10 +21,6 @@
         <profile>
             <id>raspberry-pi-3</id>
             <activation>
-<!--                <os>
-                    <name>Linux</name>
-                    <arch>armv7l</arch>
-                </os>-->
                 <property>
                     <name>rpi</name>
                 </property>
@@ -53,7 +49,6 @@
         <profile>
             <id>default</id>
             <activation>
-               <!-- <activeByDefault>true</activeByDefault>-->
                 <property>
                     <name>!rpi</name>
                 </property>

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -21,12 +21,12 @@
         <profile>
             <id>raspberry-pi-3</id>
             <activation>
-                <os>
+<!--                <os>
                     <name>Linux</name>
                     <arch>armv7l</arch>
-                </os>
+                </os>-->
                 <property>
-                    <name>raspberry-pi-3</name>
+                    <name>rpi</name>
                 </property>
             </activation>
             <build>
@@ -53,9 +53,9 @@
         <profile>
             <id>default</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+               <!-- <activeByDefault>true</activeByDefault>-->
                 <property>
-                    <name>!raspberry-pi-3</name>
+                    <name>!rpi</name>
                 </property>
             </activation>
             <build>

--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -17,6 +17,70 @@
         <start-class>org.owasp.webgoat.WebGoat</start-class>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>raspberry-pi-3</id>
+            <activation>
+                <os>
+                    <name>Linux</name>
+                    <arch>armv7l</arch>
+                </os>
+                <property>
+                    <name>raspberry-pi-3</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.4.10</version>
+                        <configuration>
+                            <imageName>webgoat/webgoat-8.0</imageName>
+                            <dockerDirectory>src/main/docker_rpi3</dockerDirectory>
+                            <resources>
+                                <resource>
+                                    <targetPath>/</targetPath>
+                                    <directory>${project.build.directory}</directory>
+                                    <include>${project.build.finalName}.war</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!raspberry-pi-3</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.4.10</version>
+                        <configuration>
+                            <imageName>webgoat/webgoat-8.0</imageName>
+                            <dockerDirectory>src/main/docker</dockerDirectory>
+                            <resources>
+                                <resource>
+                                    <targetPath>/</targetPath>
+                                    <directory>${project.build.directory}</directory>
+                                    <include>${project.build.finalName}.war</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <resources>
             <resource>
@@ -34,22 +98,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>0.4.10</version>
-                <configuration>
-                    <imageName>webgoat/webgoat-8.0</imageName>
-                    <dockerDirectory>src/main/docker</dockerDirectory>
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.war</include>
-                        </resource>
-                    </resources>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/webgoat-container/src/main/docker_rpi3/Dockerfile
+++ b/webgoat-container/src/main/docker_rpi3/Dockerfile
@@ -1,0 +1,10 @@
+# Baseimage specially for raspberry pi usage
+FROM resin/rpi-raspbian:jessie
+VOLUME /tmp
+# Installing openjdk-8-headless like in the standard Webgoat Docker container
+RUN apt-get update && apt-get install -y \
+      openjdk-8-jre-headless
+RUN cd /root; mkdir -p .webgoat
+ADD webgoat-container-8.0-SNAPSHOT.war webgoat.jar
+RUN sh -c 'touch /webgoat.jar'
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/webgoat.jar"]


### PR DESCRIPTION
Hi,
since the currently build container cannot be used on a Raspberry Pi I've extended the current project. 

Therefore I've added a new Dockerfile and extended _web-container_'s `pom.xml`. Documentation how to use the changes have been added to the `README.md`. 
I'm not sure if the solution to use a property to decide wether to build the container or ARM or not is the best - if it's not just give me a hint how to solve it properly.