### PR TITLE
Basic lessons for WebGoat 8, as seen in WebGoat 7

### DIFF
--- a/webgoat-lessons/bypass-restrictions/pom.xml
+++ b/webgoat-lessons/bypass-restrictions/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>bypass-restrictions</artifactId>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.owasp.webgoat.lesson</groupId>
+        <artifactId>webgoat-lessons-parent</artifactId>
+        <version>8.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>4.1.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/webgoat-lessons/bypass-restrictions/src/main/java/org/owasp/webgoat/plugin/BypassRestrictions.java
+++ b/webgoat-lessons/bypass-restrictions/src/main/java/org/owasp/webgoat/plugin/BypassRestrictions.java
@@ -1,0 +1,63 @@
+package org.owasp.webgoat.plugin;
+
+import com.beust.jcommander.internal.Lists;
+import org.owasp.webgoat.lessons.Category;
+import org.owasp.webgoat.lessons.NewLesson;
+
+import java.util.List;
+
+/**
+ * ************************************************************************************************
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ * <p>
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ * <p>
+ * Getting Source ==============
+ * <p>
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ * <p>
+ *
+ * @author WebGoat
+ * @version $Id: $Id
+ * @since October 12, 2016
+ */
+public class BypassRestrictions extends NewLesson {
+    @Override
+    public Category getDefaultCategory() {
+        return Category.PARAMETER_TAMPERING;
+    }
+
+    @Override
+    public List<String> getHints() {
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public Integer getDefaultRanking() {
+        return 2;
+    }
+
+    @Override
+    public String getTitle() {
+        return "bypass-restrictions.title";
+    }
+
+    @Override
+    public String getId() {
+        return "BypassRestrictions";
+    }
+}

--- a/webgoat-lessons/bypass-restrictions/src/main/java/org/owasp/webgoat/plugin/BypassRestrictionsFieldRestrictions.java
+++ b/webgoat-lessons/bypass-restrictions/src/main/java/org/owasp/webgoat/plugin/BypassRestrictionsFieldRestrictions.java
@@ -1,0 +1,74 @@
+package org.owasp.webgoat.plugin;
+
+import org.owasp.webgoat.assignments.AssignmentEndpoint;
+import org.owasp.webgoat.assignments.AssignmentPath;
+import org.owasp.webgoat.assignments.AttackResult;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project
+ * utility. For details, please see http://www.owasp.org/
+ *
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * Getting Source ==============
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
+ * for free software projects.
+ *
+ * For details, please see http://webgoat.github.io
+ *
+ * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
+ * @created October 28, 2003
+ */
+@AssignmentPath("/BypassRestrictions/FieldRestrictions")
+public class BypassRestrictionsFieldRestrictions extends AssignmentEndpoint {
+
+    @RequestMapping(method = RequestMethod.POST)
+    public
+    @ResponseBody
+    AttackResult completed(@RequestParam String select, @RequestParam String radio, @RequestParam String checkbox, @RequestParam String shortInput) throws IOException {
+    	if (select.toString().equals("option1") || select.toString().equals("option2")) {
+        return trackProgress(failed().build());
+      }
+      if (radio.toString().equals("option1") || radio.toString().equals("option2")) {
+        return trackProgress(failed().build());
+      }
+      if (checkbox.toString().equals("on") || checkbox.toString().equals("off")) {
+        return trackProgress(failed().build());
+      }
+      if (shortInput.toString().length() <= 5) {
+        return trackProgress(failed().build());
+      }
+      /*if (disabled == null) {
+        return trackProgress(failed().build());
+      }
+      if (submit.toString().equals("submit")) {
+        return trackProgress(failed().build());
+      }*/
+        return trackProgress(success().build());
+    }
+}

--- a/webgoat-lessons/bypass-restrictions/src/main/java/org/owasp/webgoat/plugin/BypassRestrictionsFrontendValidation.java
+++ b/webgoat-lessons/bypass-restrictions/src/main/java/org/owasp/webgoat/plugin/BypassRestrictionsFrontendValidation.java
@@ -1,0 +1,87 @@
+package org.owasp.webgoat.plugin;
+
+import org.owasp.webgoat.assignments.AssignmentEndpoint;
+import org.owasp.webgoat.assignments.AssignmentPath;
+import org.owasp.webgoat.assignments.AttackResult;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project
+ * utility. For details, please see http://www.owasp.org/
+ *
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * Getting Source ==============
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
+ * for free software projects.
+ *
+ * For details, please see http://webgoat.github.io
+ *
+ * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
+ * @created October 28, 2003
+ */
+@AssignmentPath("/BypassRestrictions/frontendValidation")
+public class BypassRestrictionsFrontendValidation extends AssignmentEndpoint {
+
+    @RequestMapping(method = RequestMethod.POST)
+    public
+    @ResponseBody
+    AttackResult completed(@RequestParam String field1, @RequestParam String field2, @RequestParam String field3, @RequestParam String field4, @RequestParam String field5, @RequestParam String field6, @RequestParam String field7, @RequestParam Integer error) throws IOException {
+      String regex1="^[a-z]{3}$";
+      String regex2="^[0-9]{3}$";
+      String regex3="^[a-zA-Z0-9 ]*$";
+      String regex4="^(one|two|three|four|five|six|seven|eight|nine)$";
+      String regex5="^\\d{5}$";
+      String regex6="^\\d{5}(-\\d{4})?$";
+      String regex7="^[2-9]\\d{2}-?\\d{3}-?\\d{4}$";
+      if (error>0) {
+        return trackProgress(failed().build());
+      }
+      if (field1.matches(regex1)) {
+        return trackProgress(failed().build());
+      }
+      if (field2.matches(regex2)) {
+        return trackProgress(failed().build());
+      }
+      if (field3.matches(regex3)) {
+        return trackProgress(failed().build());
+      }
+      if (field4.matches(regex4)) {
+        return trackProgress(failed().build());
+      }
+      if (field5.matches(regex5)) {
+        return trackProgress(failed().build());
+      }
+      if (field6.matches(regex6)) {
+        return trackProgress(failed().build());
+      }
+      if (field7.matches(regex7)) {
+        return trackProgress(failed().build());
+      }
+      return trackProgress(success().build());
+    }
+}

--- a/webgoat-lessons/bypass-restrictions/src/main/resources/html/BypassRestrictions.html
+++ b/webgoat-lessons/bypass-restrictions/src/main/resources/html/BypassRestrictions.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org">
+
+    <div class="lesson-page-wrapper">
+        <!-- reuse this lesson-page-wrapper block for each 'page' of content in your lesson -->
+        <!-- include content here. Content will be presented via asciidocs files,
+        which you put in src/main/resources/plugin/lessonplans/{lang}/{fileName}.adoc -->
+        <div class="adoc-content" th:replace="doc:BypassRestrictions_Intro.adoc"></div>
+    </div>
+
+    <div class="lesson-page-wrapper">
+        <!-- stripped down without extra comments -->
+        <div class="adoc-content" th:replace="doc:BypassRestrictions_FieldRestrictions.adoc"></div>
+        <div class="attack-container">
+            <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
+            <form class="attack-form" accept-charset="UNKNOWN" name="fieldRestrictions"
+                  method="POST"
+                  action="/WebGoat/BypassRestrictions/FieldRestrictions"
+                  enctype="application/json;charset=UTF-8">
+
+                <div>Select field with two possible values</div>
+                <select name="select">
+                   <option value="option1">Option 1</option>
+                   <option value="option2">Option 2</option>
+                </select>
+                <div>Radio button with two possible values</div>
+                <input type="radio" name="radio" value="option1" checked="checked"/> Option 1<br />
+                <input type="radio" name="radio" value="option2" /> Option 2<br />
+                <div>Checkbox: value either on or off</div>
+                <input type="checkbox" name="checkbox" checked="checked"/> Checkbox
+                <div>Input restricted to max 5 characters</div>
+                <input type="text" value="12345" name="shortInput" maxlength="5"/>
+                <div>Disabled input field</div>
+                <input type="submit" value="submit"/>
+
+            </form>
+            <div class="attack-feedback"></div>
+            <div class="attack-output"></div>
+        </div>
+    </div>
+
+    <div class="lesson-page-wrapper">
+        <div class="adoc-content" th:replace="doc:BypassRestrictions_FrontendValidation.adoc"></div>
+        <div class="attack-container">
+            <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
+
+            <form class="attack-form" accept-charset="UNKNOWN" name="frontendValidation"
+                  id="frontendValidation"
+                  method="POST"
+                  action="/WebGoat/BypassRestrictions/frontendValidation/"
+                  enctype="application/json;charset=UTF-8"
+                  onsubmit="return validate()">
+                <div>
+                  Field1: exactly three lowercase characters(^[a-z]{3}$)
+                </div>
+                <div>
+                  <textarea cols="25" name="field1" rows="1">abc</textarea>
+                </div>
+                <p></p>
+                <div>Field2: exactly three digits(^[0-9]{3}$)</div>
+                <div>
+                  <textarea cols="25" name="field2" rows="1">123</textarea>
+                </div>
+                <p></p>
+                <div>Field3: letters, numbers, and space only(^[a-zA-Z0-9 ]*$)</div>
+                <div>
+                  <textarea cols="25" name="field3" rows="1">abc 123 ABC</textarea>
+                </div>
+                <p></p>
+                <div>Field4: enumeration of numbers (^(one|two|three|four|five|six|seven|eight|nine)$)</div>
+                <div>
+                  <textarea cols="25" name="field4" rows="1">seven</textarea>
+                </div>
+                <p></p>
+                <div>Field5: simple zip code (^\d{5}$)</div>
+                <div>
+                  <textarea cols="25" name="field5" rows="1">01101</textarea>
+                </div>
+                <p></p>
+                <div>Field6: zip with optional dash four (^\d{5}(-\d{4})?$)</div>
+                <div>
+                  <textarea cols="25" name="field6" rows="1">90210-1111</textarea>
+                </div>
+                <p></p>
+                <div>Field7: US phone number with or without dashes (^[2-9]\d{2}-?\d{3}-?\d{4}$)</div>
+                <div>
+                  <textarea cols="25" name="field7" rows="1">301-604-4882</textarea>
+                </div>
+                <input type="hidden" value="" name="error" />
+                <p><input type="submit" value="Submit" /></p>
+            </form>
+
+            <script>
+            let regex1=/^[a-z]{3}$/;
+            let regex2=/^[0-9]{3}$/;
+            let regex3=/^[a-zA-Z0-9 ]*$/;
+            let regex4=/^(one|two|three|four|five|six|seven|eight|nine)$/;
+            let regex5=/^\d{5}$/;
+            let regex6=/^\d{5}(-\d{4})?$/;
+            let regex7=/^[2-9]\d{2}-?\d{3}-?\d{4}$/;
+            var validate = function() {
+              let msg='JavaScript found form errors';
+              let err=0;
+              if (!regex1.test(document.frontendValidation.field1.value)) {err+=1; msg+='\n  bad field1';}
+              if (!regex2.test(document.frontendValidation.field2.value)) {err+=1; msg+='\n  bad field2';}
+              if (!regex3.test(document.frontendValidation.field3.value)) {err+=1; msg+='\n  bad field3';}
+              if (!regex4.test(document.frontendValidation.field4.value)) {err+=1; msg+='\n  bad field4';}
+              if (!regex5.test(document.frontendValidation.field5.value)) {err+=1; msg+='\n  bad field5';}
+              if (!regex6.test(document.frontendValidation.field6.value)) {err+=1; msg+='\n  bad field6';}
+              if (!regex7.test(document.frontendValidation.field7.value)) {err+=1; msg+='\n  bad field7';}
+              document.frontendValidation.error.value = err
+              if ( err > 0 ) {
+                alert(msg)
+                return false;
+              }
+              return true;
+            }
+            </script>
+            <div class="attack-feedback"></div>
+            <div class="attack-output"></div>
+        </div>
+    </div>
+</html>

--- a/webgoat-lessons/bypass-restrictions/src/main/resources/i18n/WebGoatLabels.properties
+++ b/webgoat-lessons/bypass-restrictions/src/main/resources/i18n/WebGoatLabels.properties
@@ -1,0 +1,4 @@
+bypass-restrictions.title=Bypass front-end restrictions
+
+bypass-restrictions.intercept.success=Well done, you intercepted the request as expected
+bypass-restrictions.intercept.failure=Please try again. Make sure to make all the changes. And case sensitivity may matter ... or not, you never know!

--- a/webgoat-lessons/bypass-restrictions/src/main/resources/lessonPlans/en/BypassRestrictions_FieldRestrictions.adoc
+++ b/webgoat-lessons/bypass-restrictions/src/main/resources/lessonPlans/en/BypassRestrictions_FieldRestrictions.adoc
@@ -1,0 +1,6 @@
+== Field Restrictions
+In most browsers, client has complete or almost complete control over HTML part
+of the webpage. They can alter values or restrictions to fit their preference.
+
+=== Task
+Send a request that bypasses restrictions of all four of these fields

--- a/webgoat-lessons/bypass-restrictions/src/main/resources/lessonPlans/en/BypassRestrictions_FrontendValidation.adoc
+++ b/webgoat-lessons/bypass-restrictions/src/main/resources/lessonPlans/en/BypassRestrictions_FrontendValidation.adoc
@@ -1,0 +1,8 @@
+== Validation
+Often, there is some mechanism in place to prevent users from sending altered
+field values to server, such as validation before sending. Most of popular browsers
+such as Chrome don't allow editing scripts during runtime. We will have to circumvent
+the validation some other way.
+
+=== Task
+Send a request that does not fit the regular expression above the field in all fields.

--- a/webgoat-lessons/bypass-restrictions/src/main/resources/lessonPlans/en/BypassRestrictions_Intro.adoc
+++ b/webgoat-lessons/bypass-restrictions/src/main/resources/lessonPlans/en/BypassRestrictions_Intro.adoc
@@ -1,0 +1,10 @@
+
+== Concept
+Users have a great degree of control over the front-end of the web application.
+They can alter HTML code, sometimes also scripts. This is why
+apps that require certain format of input should also validate on server-side.
+
+== Goals
+* The user should have a basic knowledge of HTML
+* The user should be able to tamper a request before sending (with proxy or other tool)
+* The user will be able to tamper with field restrictions and bypass client-side validation

--- a/webgoat-lessons/html-tampering/pom.xml
+++ b/webgoat-lessons/html-tampering/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>html-tampering</artifactId>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.owasp.webgoat.lesson</groupId>
+        <artifactId>webgoat-lessons-parent</artifactId>
+        <version>8.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>4.1.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/webgoat-lessons/html-tampering/src/main/java/org/owasp/webgoat/plugin/HtmlTampering.java
+++ b/webgoat-lessons/html-tampering/src/main/java/org/owasp/webgoat/plugin/HtmlTampering.java
@@ -1,0 +1,63 @@
+package org.owasp.webgoat.plugin;
+
+import com.beust.jcommander.internal.Lists;
+import org.owasp.webgoat.lessons.Category;
+import org.owasp.webgoat.lessons.NewLesson;
+
+import java.util.List;
+
+/**
+ * ************************************************************************************************
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ * <p>
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ * <p>
+ * Getting Source ==============
+ * <p>
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ * <p>
+ *
+ * @author WebGoat
+ * @version $Id: $Id
+ * @since October 12, 2016
+ */
+public class HtmlTampering extends NewLesson {
+    @Override
+    public Category getDefaultCategory() {
+        return Category.PARAMETER_TAMPERING;
+    }
+
+    @Override
+    public List<String> getHints() {
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public Integer getDefaultRanking() {
+        return 3;
+    }
+
+    @Override
+    public String getTitle() {
+        return "html-tampering.title";
+    }
+
+    @Override
+    public String getId() {
+        return "HtmlTampering";
+    }
+}

--- a/webgoat-lessons/html-tampering/src/main/java/org/owasp/webgoat/plugin/HtmlTamperingTask.java
+++ b/webgoat-lessons/html-tampering/src/main/java/org/owasp/webgoat/plugin/HtmlTamperingTask.java
@@ -1,0 +1,59 @@
+package org.owasp.webgoat.plugin;
+
+import org.owasp.webgoat.assignments.AssignmentEndpoint;
+import org.owasp.webgoat.assignments.AssignmentPath;
+import org.owasp.webgoat.assignments.AttackResult;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project
+ * utility. For details, please see http://www.owasp.org/
+ *
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * Getting Source ==============
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
+ * for free software projects.
+ *
+ * For details, please see http://webgoat.github.io
+ *
+ * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
+ * @created October 28, 2003
+ */
+@AssignmentPath("/HtmlTampering/task")
+public class HtmlTamperingTask extends AssignmentEndpoint {
+
+    @RequestMapping(method = RequestMethod.POST)
+    public
+    @ResponseBody
+    AttackResult completed(@RequestParam String QTY, @RequestParam String Total) throws IOException {
+    	if (Float.parseFloat(QTY) * 2999.99 > Float.parseFloat(Total) + 1) {
+    		return trackProgress(success().feedback("html-tampering.tamper.success").build());
+    	}
+        return trackProgress(failed().feedback("html-tampering.tamper.failure").build());
+    }
+}

--- a/webgoat-lessons/html-tampering/src/main/resources/html/HtmlTampering.html
+++ b/webgoat-lessons/html-tampering/src/main/resources/html/HtmlTampering.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org">
+
+    <div class="lesson-page-wrapper">
+        <!-- reuse this lesson-page-wrapper block for each 'page' of content in your lesson -->
+        <!-- include content here. Content will be presented via asciidocs files,
+        which you put in src/main/resources/plugin/lessonplans/{lang}/{fileName}.adoc -->
+        <div class="adoc-content" th:replace="doc:HtmlTampering_Intro.adoc"></div>
+    </div>
+
+    <div class="lesson-page-wrapper">
+        <!-- stripped down without extra comments -->
+        <div class="adoc-content" th:replace="doc:HtmlTampering_Task.adoc"></div>
+        <div class="attack-container">
+            <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
+            <form class="attack-form" accept-charset="UNKNOWN" name="task"
+                  method="POST"
+                  action="/WebGoat/HtmlTampering/task"
+                  enctype="application/json;charset=UTF-8">
+                <script>
+                    let regex=/^2999.99$/
+                    let price = 2999.99
+                    document.getElementById("total").innerHTML =  '$' + price.toString()
+                    document.task.Total.value = price * document.task.QTY.value
+
+                    $('#task').submit(function() {
+                      if (!regex.test(price.toString())) {
+                          alert('Data tampering is disallowed')
+                          price = 2999.99
+                          return false
+                      }
+                      else {
+                        return true
+                      }
+                    })
+
+                    function update() {
+                      let total = price * document.task.QTY.value
+                      document.getElementById("total").innerHTML = total.toString()
+                      document.task.Total.value = total
+                    }
+                </script>
+                <center>
+                    <h1>Shopping Cart </h1>
+                </center>
+                <br />
+                <table align="center" cellspacing="0" width="90%" border="1" cellpadding="2">
+                    <tbody>
+                        <tr>
+                            <th width="80%">Shopping Cart Items  To Buy Now</th>
+                            <th width="10%">Price</th>
+                            <th width="3%">Quantity</th>
+                            <th width="7%">Total</th>
+                        </tr>
+                        <tr>
+                            <td>56 inch HDTV (model KTV-551)</td>
+                            <td align="right">2999.99</td>
+                            <td align="right">
+                                <input size="6" value="1" name="QTY" type="TEXT" id="QTY"/>
+                            </td>
+                            <td id="total"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <br />
+                <table align="center" cellspacing="0" width="90%" border="0" cellpadding="2">
+                    <tbody>
+                        <tr>
+                            <td>The total charged to your credit card:</td>
+                            <td>$2999,99</td>
+                            <td>
+                                <input name="UPDATE" type="button" value="UpdateCart" onclick="update()"/>
+                            </td>
+                            <td>
+                                <input value="Purchase" name="SUBMIT" type="submit" />
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <input name="Total" type="HIDDEN" value="2999.99" />
+                <br />
+
+
+            </form>
+            <br></br>
+            <div class="attack-feedback"></div>
+            <div class="attack-output"></div>
+        </div>
+    </div>
+</html>

--- a/webgoat-lessons/html-tampering/src/main/resources/i18n/WebGoatLabels.properties
+++ b/webgoat-lessons/html-tampering/src/main/resources/i18n/WebGoatLabels.properties
@@ -1,0 +1,5 @@
+html-tampering.title=HTML tampering
+
+
+html-tampering.tamper.success=Well done, you just bought a TV at a discount
+html-tampering.tamper.failure=This is too expensive... You need to buy at a cheaper cost!

--- a/webgoat-lessons/html-tampering/src/main/resources/lessonPlans/en/HtmlTampering_Intro.adoc
+++ b/webgoat-lessons/html-tampering/src/main/resources/lessonPlans/en/HtmlTampering_Intro.adoc
@@ -1,0 +1,7 @@
+
+== Concept
+Browsers generally offer many options of editing the displayed content. Developers
+therefore must be aware that the values sent by the user may have been tampered with.
+== Goals
+* The user should have a basic understanding of HTML
+* The user will be able to exploit editing front end of website

--- a/webgoat-lessons/html-tampering/src/main/resources/lessonPlans/en/HtmlTampering_Task.adoc
+++ b/webgoat-lessons/html-tampering/src/main/resources/lessonPlans/en/HtmlTampering_Task.adoc
@@ -1,0 +1,2 @@
+=== Try it yourself
+This is an internet store. Try to buy TV-s for a lower price.

--- a/webgoat-lessons/insecure-login/pom.xml
+++ b/webgoat-lessons/insecure-login/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>insecure-login</artifactId>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.owasp.webgoat.lesson</groupId>
+        <artifactId>webgoat-lessons-parent</artifactId>
+        <version>8.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>4.1.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/webgoat-lessons/insecure-login/src/main/java/org/owasp/webgoat/plugin/InsecureLogin.java
+++ b/webgoat-lessons/insecure-login/src/main/java/org/owasp/webgoat/plugin/InsecureLogin.java
@@ -1,0 +1,63 @@
+package org.owasp.webgoat.plugin;
+
+import com.beust.jcommander.internal.Lists;
+import org.owasp.webgoat.lessons.Category;
+import org.owasp.webgoat.lessons.NewLesson;
+
+import java.util.List;
+
+/**
+ * ************************************************************************************************
+ * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
+ * please see http://www.owasp.org/
+ * <p>
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ * <p>
+ * Getting Source ==============
+ * <p>
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository for free software
+ * projects.
+ * <p>
+ *
+ * @author WebGoat
+ * @version $Id: $Id
+ * @since October 12, 2016
+ */
+public class InsecureLogin extends NewLesson {
+    @Override
+    public Category getDefaultCategory() {
+        return Category.INSECURE_COMMUNICATION;
+    }
+
+    @Override
+    public List<String> getHints() {
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public Integer getDefaultRanking() {
+        return 1;
+    }
+
+    @Override
+    public String getTitle() {
+        return "insecure-login.title";
+    }
+
+    @Override
+    public String getId() {
+        return "InsecureLogin";
+    }
+}

--- a/webgoat-lessons/insecure-login/src/main/java/org/owasp/webgoat/plugin/InsecureLoginTask.java
+++ b/webgoat-lessons/insecure-login/src/main/java/org/owasp/webgoat/plugin/InsecureLoginTask.java
@@ -1,0 +1,59 @@
+package org.owasp.webgoat.plugin;
+
+import org.owasp.webgoat.assignments.AssignmentEndpoint;
+import org.owasp.webgoat.assignments.AssignmentPath;
+import org.owasp.webgoat.assignments.AttackResult;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * *************************************************************************************************
+ *
+ *
+ * This file is part of WebGoat, an Open Web Application Security Project
+ * utility. For details, please see http://www.owasp.org/
+ *
+ * Copyright (c) 2002 - 20014 Bruce Mayhew
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * Getting Source ==============
+ *
+ * Source for this application is maintained at https://github.com/WebGoat/WebGoat, a repository
+ * for free software projects.
+ *
+ * For details, please see http://webgoat.github.io
+ *
+ * @author Bruce Mayhew <a href="http://code.google.com/p/webgoat">WebGoat</a>
+ * @created October 28, 2003
+ */
+@AssignmentPath("/InsecureLogin/task")
+public class InsecureLoginTask extends AssignmentEndpoint {
+
+    @RequestMapping(method = RequestMethod.POST)
+    public
+    @ResponseBody
+    AttackResult completed(@RequestParam String username, @RequestParam String password) throws IOException {
+    	if (username.toString().equals("CaptainJack") && password.toString().equals("BlackPearl")) {
+    		return trackProgress(success().build());
+    	}
+        return trackProgress(failed().build());
+    }
+}

--- a/webgoat-lessons/insecure-login/src/main/resources/html/InsecureLogin.html
+++ b/webgoat-lessons/insecure-login/src/main/resources/html/InsecureLogin.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org">
+
+    <div class="lesson-page-wrapper">
+        <!-- reuse this lesson-page-wrapper block for each 'page' of content in your lesson -->
+        <!-- include content here. Content will be presented via asciidocs files,
+        which you put in src/main/resources/plugin/lessonplans/{lang}/{fileName}.adoc -->
+        <div class="adoc-content" th:replace="doc:InsecureLogin_Intro.adoc"></div>
+    </div>
+
+    <div class="lesson-page-wrapper">
+        <!-- stripped down without extra comments -->
+        <div class="adoc-content" th:replace="doc:InsecureLogin_Task.adoc"></div>
+        <div class="attack-container">
+            <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
+            <script th:src="@{/lesson_js/credentials.js}"
+                    language="JavaScript"></script>
+            <form class="attack-form" accept-charset="UNKNOWN" name="task"
+                  method="POST"
+                  action="#attack/307/100"
+                  enctype="application/json;charset=UTF-8">
+<!---
+                <input type="hidden" value="" name="username" id="SecretUsername"/>
+                <input type="hidden" value="" name="password" id="SecretPassword"/>
+                <input type="button" value="Log in" onpress="submit_secret_credentials()"/>-->
+                <button onclick="submit_secret_credentials()">Log in</button>
+
+            </form>
+            <br></br>
+            <form class="attack-form" accept-charset="UNKNOWN" name="task"
+                  method="POST"
+                  action="/WebGoat/InsecureLogin/task"
+                  enctype="application/json;charset=UTF-8">
+
+                <input type="text" value="" name="username" placeholder="username"/>
+                <input type="password" value="" name="password" placeholder="password" />
+                <input type="submit" value="Submit" />
+
+            </form>
+            <div class="attack-feedback"></div>
+            <div class="attack-output"></div>
+        </div>
+    </div>
+</html>

--- a/webgoat-lessons/insecure-login/src/main/resources/i18n/WebGoatLabels.properties
+++ b/webgoat-lessons/insecure-login/src/main/resources/i18n/WebGoatLabels.properties
@@ -1,0 +1,4 @@
+insecure-login.title=Insecure Login
+
+insecure-login.intercept.success=Welcome, CaptainJack!
+insecure-login.intercept.failure=Wrong username or password

--- a/webgoat-lessons/insecure-login/src/main/resources/js/credentials.js
+++ b/webgoat-lessons/insecure-login/src/main/resources/js/credentials.js
@@ -1,0 +1,6 @@
+function submit_secret_credentials() {
+    var xhttp = new XMLHttpRequest();
+    xhttp['open']('POST', '#attack/307/100', true);
+	//sending the request is obfuscated, to descourage js reading
+	var _0xb7f9=["\x43\x61\x70\x74\x61\x69\x6E\x4A\x61\x63\x6B","\x42\x6C\x61\x63\x6B\x50\x65\x61\x72\x6C","\x73\x74\x72\x69\x6E\x67\x69\x66\x79","\x73\x65\x6E\x64"];xhttp[_0xb7f9[3]](JSON[_0xb7f9[2]]({username:_0xb7f9[0],password:_0xb7f9[1]}))
+}

--- a/webgoat-lessons/insecure-login/src/main/resources/lessonPlans/en/InsecureLogin_Intro.adoc
+++ b/webgoat-lessons/insecure-login/src/main/resources/lessonPlans/en/InsecureLogin_Intro.adoc
@@ -1,0 +1,7 @@
+
+== Concept
+Encryption is a very inportant tool for secure communication. In this lesson, we will find out, why it should always be employed when sending sensitive data.
+
+== Goals
+* The user should have a basic understanding of packet sniffer usage
+* The user will be able to intercept and read an unencrypted requests

--- a/webgoat-lessons/insecure-login/src/main/resources/lessonPlans/en/InsecureLogin_Task.adoc
+++ b/webgoat-lessons/insecure-login/src/main/resources/lessonPlans/en/InsecureLogin_Task.adoc
@@ -1,0 +1,4 @@
+=== Let's try
+Click the "log in" button to send a request containing login credentials of another user.
+Then, write these credentials into the appropriate fields and submit to confirm.
+Try using a packet sniffer to intercept the request.

--- a/webgoat-lessons/pom.xml
+++ b/webgoat-lessons/pom.xml
@@ -19,6 +19,7 @@
         <module>cross-site-scripting</module>
         <module>http-basics</module>
         <module>http-proxies</module>
+        <module>insecure-login</module>
         <module>jwt</module>
         <module>sql-injection</module>
         <module>xxe</module>

--- a/webgoat-lessons/pom.xml
+++ b/webgoat-lessons/pom.xml
@@ -14,6 +14,7 @@
     </parent>
 
     <modules>
+        <module>bypass-restrictions</module>
         <module>challenge</module>
         <module>client-side-filtering</module>
         <module>cross-site-scripting</module>

--- a/webgoat-lessons/pom.xml
+++ b/webgoat-lessons/pom.xml
@@ -17,6 +17,7 @@
         <module>challenge</module>
         <module>client-side-filtering</module>
         <module>cross-site-scripting</module>
+        <module>html-tampering</module>
         <module>http-basics</module>
         <module>http-proxies</module>
         <module>insecure-login</module>

--- a/webgoat-server/pom.xml
+++ b/webgoat-server/pom.xml
@@ -118,6 +118,11 @@
         </dependency>
         <dependency>
             <groupId>org.owasp.webgoat.lesson</groupId>
+            <artifactId>insecure-login</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.webgoat.lesson</groupId>
             <artifactId>jwt</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/webgoat-server/pom.xml
+++ b/webgoat-server/pom.xml
@@ -103,6 +103,11 @@
         </dependency>
         <dependency>
             <groupId>org.owasp.webgoat.lesson</groupId>
+            <artifactId>html-tampering</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.webgoat.lesson</groupId>
             <artifactId>http-basics</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/webgoat-server/pom.xml
+++ b/webgoat-server/pom.xml
@@ -93,6 +93,11 @@
         <!--</dependency>-->
         <dependency>
             <groupId>org.owasp.webgoat.lesson</groupId>
+            <artifactId>bypass-restrictions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.owasp.webgoat.lesson</groupId>
             <artifactId>client-side-filtering</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
I remade WebGoat 7.1 lessons for HTML tampering, bypassing javascript validation and sniffing HTTP requests. There are some changes, for example no disabled field in front-end restrictions lesson, because I haven't figured out how to request a parameter for validation that hasn't been there. Also, the lesson for HTML tampering ("buying the TV in online store") is slightly altered, so that the lesson is not passed on update of the cart but actual buying of the TV.