### PR TITLE
Fix Apt Error for Google Repository

### DIFF
--- a/webgoat-images/vagrant_provision.sh
+++ b/webgoat-images/vagrant_provision.sh
@@ -14,7 +14,7 @@ sudo apt-get install -y -q build-essential autotools-dev automake pkg-config exp
 
 ## Chrome
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 sudo apt-get update
 sudo apt-get install -y google-chrome-stable
 


### PR DESCRIPTION
Fixes an error while installing Google Chrome:
```
Failed to fetch http://dl.google.com/linux/chrome/deb/dists/stable/Release 
Unable to find expected entry 'main/binary-i386/Packages' in Release file
(Wrong sources.list entry or malformed file)  
Some index files failed to download.  
They have been ignored, or old ones used instead.
```

See https://askubuntu.com/questions/724093/no-more-updates-for-google-chrome-apt-get-update-error