### PR TITLE
Fix next page button when url doesn't end with page number

### DIFF
--- a/webgoat-container/src/main/resources/static/js/goatApp/model/LessonContentModel.js
+++ b/webgoat-container/src/main/resources/static/js/goatApp/model/LessonContentModel.js
@@ -32,7 +32,11 @@ define(['jquery',
             }
             this.set('content',content);
             this.set('lessonUrl',document.URL.replace(/\.lesson.*/,'.lesson'));
-            this.set('pageNum',document.URL.replace(/.*\.lesson\/(\d{1,4})$/,'$1'));
+            if (/.*\.lesson\/(\d{1,4})$/.test(document.URL)) {
+                this.set('pageNum',document.URL.replace(/.*\.lesson\/(\d{1,4})$/,'$1'));
+            } else {
+                this.set('pageNum',0);
+            }
             this.trigger('content:loaded',this,loadHelps);
         },
 


### PR DESCRIPTION
This fixes the next page button when the current url doesn't end with the page number like in http://localhost:8080/WebGoat/start.mvc#lesson/IDOR.lesson