### PR TITLE
Small fixes for lesson about XSS

### DIFF
--- a/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/StoredXssComments.java
+++ b/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/StoredXssComments.java
@@ -49,10 +49,7 @@ import org.owasp.encoder.*;
 
 import static org.springframework.http.MediaType.ALL_VALUE;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
@@ -72,20 +69,19 @@ public class StoredXssComments extends AssignmentEndpoint {
         comments.add(new Comment("secUriTy", DateTime.now().toString(fmt), "<script>console.warn('unit test me')</script>Comment for Unit Testing"));
         comments.add(new Comment("webgoat", DateTime.now().toString(fmt), "This comment is safe"));
         comments.add(new Comment("guest", DateTime.now().toString(fmt), "This one is safe too."));
-        comments.add(new Comment("guest", DateTime.now().toString(fmt), "Can you post a comment,  calling webgoat.customjs.phoneHome() ?"));
+        comments.add(new Comment("guest", DateTime.now().toString(fmt), "Can you post a comment, calling webgoat.customjs.phoneHome() ?"));
     }
 
     @RequestMapping(method = GET, produces = MediaType.APPLICATION_JSON_VALUE,consumes = ALL_VALUE)
     @ResponseBody
     public Collection<Comment> retrieveComments() {
-        Collection<Comment> allComments = Lists.newArrayList();
+        List<Comment> allComments = Lists.newArrayList();
         Collection<Comment> newComments = userComments.get(webSession.getUserName());
+        allComments.addAll(comments);
         if (newComments != null) {
             allComments.addAll(newComments);
         }
-
-        allComments.addAll(comments);
-
+        Collections.reverse(allComments);
         return allComments;
     }
 

--- a/webgoat-lessons/cross-site-scripting/src/main/resources/i18n/WebGoatLabels.properties
+++ b/webgoat-lessons/cross-site-scripting/src/main/resources/i18n/WebGoatLabels.properties
@@ -5,7 +5,7 @@ xss-reflected-5a-failure=Try again. We do want to see this specific javascript (
 xss-reflected-5b-success=Correct ... because <ul><li>The script was not triggered by the URL/QueryString</li><li>Even if you use the attack URL in a new tab, it won't execute (becuase of response type). Try it if you like.</li></ul>
 xss-reflected-5b-failure=Nope, pretty easy to guess now though.
 xss-reflected-6a-success=Correct! Now, see if you can send in an exploit to that route in the next assignment.
-xss-reflected-6a-failure=No, look at the example. Check the GoatRouter.js file. It should be pretty easy to determine.
+xss-reflected-6a-failure=No, look at the example. Check the <a href="/WebGoat/js/goatApp/view/GoatRouter.js" target="_blank">GoatRouter.js</a> file. It should be pretty easy to determine.
 xss.lesson1.failure=Are you sure? Try using a tab from a different site.
 xss-dom-message-success=Correct, I hope you didn't cheat, using the console!
 xss-dom-message-failure=Incorrect, keep trying. It should be obvious in the log when you are successful.

--- a/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content5b.adoc
+++ b/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content5b.adoc
@@ -4,7 +4,7 @@ You should have been able to execute script with the last example. At this point
 
 Why is that?
 
-That is because there is no link that would tigger that XSS.
+That is because there is no link that would trigger that XSS.
 You can try it yourself to see what happens ... go to (substitute localhost with your server's name or IP if you need to):
 
-link: http://localhost:8080/WebGoat/CrossSiteScripting/attack5a?QTY1=1&QTY2=1&QTY3=1&QTY4=1&field1=<script>alert('myjavascripthere')</script>4128+3214+0002+1999&field2=111
+link: http://localhost:8080/WebGoat/CrossSiteScripting/attack5a?QTY1=1&QTY2=1&QTY3=1&QTY4=1&field1=<script>alert('my%20javascript%20here')</script>4128+3214+0002+1999&field2=111

--- a/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content6a.adoc
+++ b/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content6a.adoc
@@ -1,4 +1,4 @@
-== Ientify Potential for DOM-Based XSS
+== Identify Potential for DOM-Based XSS
 
 DOM-Based XSS can usually be found by looking for the route configurations in the client-side code.
 Look for a route that takes inputs that you can ID being 'reflected' to the page.
@@ -7,7 +7,7 @@ For this example, you'll want to look for some 'test' code in the route handlers
 Sometimes, test code gets left in production (and often times test code is very simple and lacks security or any quality controls!).
 
 Your objective is to find the route and exploit it. First though ... what is the base route? As an example, look at the URL for this lesson ...
-it should look something like /WebGoat/start.mvc#lesson/CrossSiteScripting.lesson/5 (although maybe slightly different). The 'base route' in this case is:
+it should look something like /WebGoat/start.mvc#lesson/CrossSiteScripting.lesson/9 (although maybe slightly different). The 'base route' in this case is:
 *start.mvc#lesson/*
 
 The *CrossSiteScripting.lesson/#* after that are parameters that are processed by javascript route handler.


### PR DESCRIPTION
This PR fixes some spelling errors in the lesson about XSS.

It also reverses the order of how comments are displayed during the last part of the lesson, so that newest comments are shown on top. This is not as intuitive but it mitigates the problem that a user might create a comment containing invalid HTML, which prevents all following comments from being rendered. With the order reversed the user can still add new comments to complete the task.