### PR TITLE
Update Webgoat Dockerfile to use entrypoints and commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "8080:8080"
     volumes:
       - .:/home/webgoat/.webgoat
-    command: "java -Djava.security.egd=file:/dev/./urandom -jar /home/webgoat/webgoat.jar --server.port=8080 --server.address=0.0.0.0"
   webwolf:
     image: webgoat/webwolf
     ports:

--- a/webgoat-server/Dockerfile
+++ b/webgoat-server/Dockerfile
@@ -11,3 +11,6 @@ RUN cd /home/webgoat/; mkdir -p .webgoat-${webgoat_version}
 COPY target/webgoat-server-${webgoat_version}.jar /home/webgoat/webgoat.jar
 
 EXPOSE 8080
+
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/home/webgoat/webgoat.jar"]
+CMD ["--server.port=8080", "--server.address=0.0.0.0"]


### PR DESCRIPTION
Work still needs to be done to get the current docker-compose.yml file to work with `webgoat/webwolf:latest`, but this is a step in the right direction.

This updates the WebGoat Dockerfile to follow Docker best practices for entrypoints and commands: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint

This will allow a user to change the flags as desired by overriding the command parameter, while keeping the critical section `java -Djava.security.egd=file:/dev/./urandom -jar /home/webgoat/webgoat.jar` untouched.