### PR TITLE
Fix SQL injection mitigation answer (fixes #505)

### DIFF
--- a/webgoat-lessons/sql-injection/src/main/java/org/owasp/webgoat/plugin/mitigation/SqlInjectionLesson12a.java
+++ b/webgoat-lessons/sql-injection/src/main/java/org/owasp/webgoat/plugin/mitigation/SqlInjectionLesson12a.java
@@ -33,7 +33,7 @@ public class SqlInjectionLesson12a extends AssignmentEndpoint {
     @SneakyThrows
     public AttackResult completed(@RequestParam String ip) {
         Connection connection = DatabaseUtilities.getConnection(webSession);
-        PreparedStatement preparedStatement = connection.prepareStatement("select ip from servers where ip = ?");
+        PreparedStatement preparedStatement = connection.prepareStatement("select ip from servers where hostname = 'webgoat-prd' and ip = ?");
         preparedStatement.setString(1, ip);
         ResultSet resultSet = preparedStatement.executeQuery();
         if (resultSet.next()) {


### PR DESCRIPTION
See #505 for the issue description.

In this lesson, you have to perform SQL injection in the `ORDER BY` clause. By making a case distinction, you are supposed to find out what the IP is of the `webgoat-prd` server. But if you submit it, WebGoat just checks if you filled in the IP of any of the servers in the database instead of the specific IP of `webgoat-prd`.

Fixed this by adding the hostname to the where clause.