### PR TITLE
encapsulated the WEBGOAT_HOME in quotes

### DIFF
--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -2,9 +2,9 @@
 
 WEBGOAT_HOME=$(pwd)/../
 
-cd ${WEBGOAT_HOME}/webgoat-server
+cd "${WEBGOAT_HOME}"/webgoat-server
 docker build -t webgoat/webgoat-v8.0.0.snapshot .
 
-cd ${WEBGOAT_HOME}/webwolf
+cd "${WEBGOAT_HOME}"/webwolf
 docker build -t webgoat/webwolf-v8.0.0.snapshot .
 


### PR DESCRIPTION
Encapsulating the `WEBGOAT_HOME` variable in quotes allows for spaces to exist in the path