### PR TITLE
fix for posting the Flag bug

### DIFF
--- a/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/Flag.java
+++ b/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/Flag.java
@@ -56,7 +56,7 @@ public class Flag extends Endpoint {
     @RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public AttackResult postFlag(@RequestParam String flag) {
-        UserTracker userTracker = userTrackerRepository.findOne(webSession.getUserName());
+        UserTracker userTracker = userTrackerRepository.findByUser(webSession.getUserName());
         String currentChallenge = webSession.getCurrentLesson().getName();
         int challengeNumber = Integer.valueOf(currentChallenge.substring(currentChallenge.length() - 1, currentChallenge.length()));
         String expectedFlag = FLAGS.get(challengeNumber);


### PR DESCRIPTION
#568 
findOne changed to findByUser to fix the bug when trying to post the flag. 

The bug is caused by findOne which expects the type of the ID field which is Long and not String