### PR TITLE
Fix chrome tool lesson

### DIFF
--- a/webgoat-lessons/chrome-dev-tools/src/main/resources/lessonPlans/en/ChromeDevTools_Assignment_Network.adoc
+++ b/webgoat-lessons/chrome-dev-tools/src/main/resources/lessonPlans/en/ChromeDevTools_Assignment_Network.adoc
@@ -2,5 +2,5 @@
 
 In this assignment you need to find a specific HTTP request and read a randomized number from it.
 To start click the first button, this wil generate an HTTP request. Try to find the specific HTTP request.
-The request should contain a field: `magic_num:`
+The request should contain a field: `networkNum:`
 Copy the number which is displayed afterwards, into the input field below and click on the check button.

--- a/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/DOMCrossSiteScripting.java
+++ b/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/DOMCrossSiteScripting.java
@@ -57,7 +57,6 @@ public class DOMCrossSiteScripting extends AssignmentEndpoint {
         userSessionData.setValue("randValue",number.nextInt());
 
         if (param1 == 42 && param2 == 24 && request.getHeader("webgoat-requested-by").equals("dom-xss-vuln")) {
-            System.out.println(userSessionData.getValue("randValue") + " << randValue");
             return trackProgress(success().output("phoneHome Response is " + userSessionData.getValue("randValue").toString()).build());
         } else {
             return trackProgress(failed().build());

--- a/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/DOMCrossSiteScripting.java
+++ b/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/DOMCrossSiteScripting.java
@@ -54,7 +54,7 @@ public class DOMCrossSiteScripting extends AssignmentEndpoint {
 
             UserSessionData userSessionData = getUserSessionData();
         SecureRandom number = new SecureRandom();
-        userSessionData.setValue("randValue",number.nextInt());
+        userSessionData.setValue("randValue",String.valueOf(number.nextInt()));
 
         if (param1 == 42 && param2 == 24 && request.getHeader("webgoat-requested-by").equals("dom-xss-vuln")) {
             return trackProgress(success().output("phoneHome Response is " + userSessionData.getValue("randValue").toString()).build());

--- a/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/DOMCrossSiteScriptingVerifier.java
+++ b/webgoat-lessons/cross-site-scripting/src/main/java/org/owasp/webgoat/plugin/DOMCrossSiteScriptingVerifier.java
@@ -55,8 +55,9 @@ public class DOMCrossSiteScriptingVerifier extends AssignmentEndpoint {
     AttackResult completed(@RequestParam String successMessage)  throws IOException {
 
         UserSessionData userSessionData = getUserSessionData();
+        String answer = (String) userSessionData.getValue("randValue");
 
-        if (successMessage.equals(userSessionData.getValue("randValue").toString())) {
+        if (successMessage.equals(answer)) {
             return trackProgress(success().feedback("xss-dom-message-success").build());
         } else {
             return trackProgress(failed().feedback("xss-dom-message-failure").build());


### PR DESCRIPTION
Small fix for the Chrome Developer Tool lesson.

If you do not run the javascript first, but immediately enter a result, a Nullpointer was triggered and no "incorrect result" was shown. 

Magic_num was changed to NetworkNum as is used in the exercise.

System.out.println is removed