### PR TITLE
password-reset forget link corrected to avoid 404

### DIFF
--- a/webgoat-lessons/password-reset/src/main/resources/html/PasswordReset.html
+++ b/webgoat-lessons/password-reset/src/main/resources/html/PasswordReset.html
@@ -226,7 +226,7 @@
                             </h4>
                             <form class="attack-form" accept-charset="UNKNOWN"
                                   method="POST" name="form"
-                                  action="/WebGoat/PasswordReset/reset/create-password-reset-link"
+                                  action="/WebGoat/PasswordReset/ForgotPassword/create-password-reset-link"
                                   enctype="application/json;charset=UTF-8" role="form">
                                 <fieldset>
         <span class="help-block">


### PR DESCRIPTION
Somehow exercise 6 had an incorrect link to the ForgotPassword.

/WebGoat/PasswordReset/reset/create-password-reset-link

was changed to /WebGoat/PasswordReset/ForgotPassword/create-password-reset-link

in the html so it matches the service