### PR TITLE
Improve intercept lesson

### DIFF
--- a/webgoat-lessons/http-proxies/src/main/resources/lessonPlans/en/HttpBasics_ProxyIntro5.adoc
+++ b/webgoat-lessons/http-proxies/src/main/resources/lessonPlans/en/HttpBasics_ProxyIntro5.adoc
@@ -19,7 +19,7 @@ modify it as follows.
 
 * Change the Method to GET
 * Add a header 'x-request-intercepted:true'
-* Change the input value 'changeMe' to 'Requests are tampered easily' (without the single quotes)
+* Remove the request body and instead send 'changeMe' as query string parameter and set the value to 'Requests are tampered easily' (without the single quotes)
 
 Then let the request continue through (by hitting the play button).
 

--- a/webgoat-lessons/http-proxies/src/test/java/org/owasp/webgoat/plugin/HttpBasicsInterceptRequestTest.java
+++ b/webgoat-lessons/http-proxies/src/test/java/org/owasp/webgoat/plugin/HttpBasicsInterceptRequestTest.java
@@ -52,7 +52,7 @@ public class HttpBasicsInterceptRequestTest extends AssignmentEndpointTest {
 
     @Test
     public void success() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/challenge/1")
+        mockMvc.perform(MockMvcRequestBuilders.get("/HttpProxies/intercept-request")
                 .header("x-request-intercepted", "true")
                 .param("changeMe", "Requests are tampered easily"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
From the existing task description it took me a while to figure out that I should send the `changeMe` parameter via the query string (it might be obvious because GET requests typically don't have an HTTP body though technically they could).

The second commit I'm not sure about (that's why it's a separate commit which I can quite easily remove). But I wondered why the URL is different to the other test case.