### PR TITLE
Make lesson csrf-7 stricter (do not allow invalid JSON, e.g. trailing =)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <commons-io.version>2.6</commons-io.version>
         <guava.version>18.0</guava.version>
         <hsqldb.version>2.3.4</hsqldb.version>
+	<jackson.version>2.9.9</jackson.version>
         <junit.version>4.12</junit.version>
         <lombok.version>1.18.4</lombok.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>

--- a/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/plugin/CSRFFeedback.java
+++ b/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/plugin/CSRFFeedback.java
@@ -1,5 +1,6 @@
 package org.owasp.webgoat.plugin;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -38,6 +39,12 @@ public class CSRFFeedback extends AssignmentEndpoint {
     @ResponseBody
     public AttackResult completed(HttpServletRequest request, @RequestBody String feedback) {
         try {
+            objectMapper.enable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES);
+            objectMapper.enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+            objectMapper.enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS);
+            objectMapper.enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY);
+            objectMapper.enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
+            objectMapper.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
             objectMapper.readValue(feedback.getBytes(), Map.class);
         } catch (IOException e) {
             return failed().feedback(ExceptionUtils.getStackTrace(e)).build();


### PR DESCRIPTION
This change forces the user to post valid JSON to WebGoat in the CSRF-7 lesson.

As `objectMapper.readValue` parses also invalid JSON, the lesson is currently a bit easier than intended.