### PR TITLE
Do not allow trivial solution to CSRF-3

### DIFF
--- a/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/plugin/CSRFGetFlag.java
+++ b/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/plugin/CSRFGetFlag.java
@@ -27,7 +27,7 @@ public class CSRFGetFlag extends Endpoint {
     @Autowired
     private PluginMessages pluginMessages;
 
-    @RequestMapping(produces = {"application/json"}, method = RequestMethod.GET)
+    @RequestMapping(produces = {"application/json"}, method = RequestMethod.POST)
     @ResponseBody
     public Map<String, Object> invoke(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 

--- a/webgoat-lessons/csrf/src/main/resources/html/CSRF.html
+++ b/webgoat-lessons/csrf/src/main/resources/html/CSRF.html
@@ -14,7 +14,7 @@
     <div class="adoc-content" th:replace="doc:CSRF_Get_Flag.adoc"></div>
 
     <form accept-charset="UNKNOWN" id="basic-csrf-get"
-          method="GET" name="form1"
+          method="POST" name="form1"
           target="_blank"
           successCallback=""
           action="/WebGoat/csrf/basic-get-flag"


### PR DESCRIPTION
In CSRF-3 use POST instead of GET  to prevent solving the assignment just by opening the URL in a new tab.