### PR TITLE
Fixed #642 - multiple tracker for one user fixed

### DIFF
--- a/webgoat-container/src/main/java/org/owasp/webgoat/users/UserService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/users/UserService.java
@@ -30,13 +30,25 @@ public class UserService implements UserDetailsService {
     }
 
     public void addUser(String username, String password) {
+        //get user if there exists one by the name
+        WebGoatUser webGoatUser = userRepository.findByUsername(username);
+        //if user exists it will be updated, otherwise created
         userRepository.save(new WebGoatUser(username, password));
-        userTrackerRepository.save(new UserTracker(username));
+        //if user previously existed it will not get another tracker
+        if (webGoatUser == null) {
+                userTrackerRepository.save(new UserTracker(username));
+        }
     }
 
     public void addUser(String username, String password, String role) {
+        //get user if there exists one by the name
+        WebGoatUser webGoatUser = userRepository.findByUsername(username);
+        //if user exists it will be updated, otherwise created
         userRepository.save(new WebGoatUser(username,password,role));
-        userTrackerRepository.save(new UserTracker(username));
+        //if user previously existed it will not get another tracker
+        if (webGoatUser == null) {
+                userTrackerRepository.save(new UserTracker(username));
+        }
     }
 
     public List<WebGoatUser> getAllUsers () {


### PR DESCRIPTION
Fixes the issue #642 

Solution:
Check if the User exists, before adding the User. If so the User will still be updated, but no additional tracker will be added.