### PR TITLE
working version with fixed link and GET for tracing purposes

### DIFF
--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
@@ -1,8 +1,6 @@
 package org.owasp.webgoat;
 
 import io.restassured.RestAssured;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.config.SSLConfig;
 import io.restassured.http.ContentType;
 import lombok.Getter;
 import org.hamcrest.CoreMatchers;
@@ -22,14 +20,11 @@ import static io.restassured.RestAssured.given;
 
 public abstract class IntegrationTest {
 
-    protected static int WG_PORT = 8843;
+    protected static int WG_PORT = 8080;
     protected static int WW_PORT = 9090;
     private static String WEBGOAT_URL = "http://127.0.0.1:" + WG_PORT + "/WebGoat/";
     private static String WEBWOLF_URL = "http://127.0.0.1:" + WW_PORT + "/";
     private static boolean WG_SSL = false;//enable this if you want to run the test on ssl
-
-    //TODO no longer required but will be removed once all usages are removed
-    protected static RestAssuredConfig restConfig = RestAssuredConfig.newConfig().sslConfig(new SSLConfig().relaxedHTTPSValidation());
     
     @Getter
     private String webGoatCookie;
@@ -248,7 +243,7 @@ public abstract class IntegrationTest {
         Assert.assertThat(
                 RestAssured.given()
                         .when()
-                        .config(restConfig)
+                        .relaxedHTTPSValidation()
                         .cookie("JSESSIONID", getWebGoatCookie())   
                         .queryParams(params)
                         .get(url)                        

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/JWTLessonTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/JWTLessonTest.java
@@ -92,7 +92,6 @@ public class JWTLessonTest extends IntegrationTest {
                         .formParam("token", generateToken(secret))
                         .post(url("/WebGoat/JWT/secret"))
                         .then()
-                        .log().all()
                         .statusCode(200)
                         .extract().path("lessonCompleted"), CoreMatchers.is(true));
     	

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/SqlInjectionMitigationTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/SqlInjectionMitigationTest.java
@@ -37,7 +37,7 @@ public class SqlInjectionMitigationTest extends IntegrationTest {
 		checkAssignment(url("/WebGoat/SqlInjectionMitigations/attack10b"), params, true);
 		
 		RestAssured.given()
-		.when().config(restConfig).cookie("JSESSIONID", getWebGoatCookie())
+		.when().relaxedHTTPSValidation().cookie("JSESSIONID", getWebGoatCookie())
 		.contentType(ContentType.JSON)
 		.get(url("/WebGoat/SqlInjectionMitigations/servers?column=(case when (true) then hostname else id end)"))
 		.then()

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/WebWolfTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/WebWolfTest.java
@@ -1,0 +1,72 @@
+package org.owasp.webgoat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.restassured.RestAssured;
+
+public class WebWolfTest extends IntegrationTest {
+    
+    @Test
+    public void runTests() throws IOException {
+        startLesson("WebWolfIntroduction");
+        
+        //Assignment 3
+        Map<String, Object> params = new HashMap<>();
+        params.clear();
+        params.put("email", getWebgoatUser()+"@webgoat.org");
+        checkAssignment(url("/WebGoat/WebWolf/mail/send"), params, false);
+        
+        String responseBody = RestAssured.given()
+                .when()
+                .relaxedHTTPSValidation()
+                .cookie("WEBWOLFSESSION", getWebWolfCookie())
+                .get(webWolfUrl("/WebWolf/mail"))
+                .then()
+                .extract().response().getBody().asString();
+        
+        String uniqueCode = responseBody.replace("%20", " ");
+        uniqueCode = uniqueCode.substring(21+uniqueCode.lastIndexOf("your unique code is: "),uniqueCode.lastIndexOf("your unique code is: ")+(21+getWebgoatUser().length()));
+        params.clear();
+        params.put("uniqueCode", uniqueCode);
+        checkAssignment(url("/WebGoat/WebWolf/mail"), params, true);
+        
+        //Assignment 4
+        RestAssured.given()
+                        .when()
+                        .relaxedHTTPSValidation()
+                        .cookie("JSESSIONID", getWebGoatCookie())   
+                        .queryParams(params)
+                        .get(url("/WebGoat/WebWolf/landing/password-reset"))                        
+                        .then()
+                        .statusCode(200);
+        RestAssured.given()
+        .when()
+        .relaxedHTTPSValidation()
+        .cookie("WEBWOLFSESSION", getWebWolfCookie())
+        .queryParams(params)
+        .get(webWolfUrl("/landing"))                        
+        .then()
+        .statusCode(200);
+        responseBody = RestAssured.given()
+                .when()
+                .relaxedHTTPSValidation()
+                .cookie("WEBWOLFSESSION", getWebWolfCookie())
+                .get(webWolfUrl("/WebWolf/requests"))
+                .then()
+                .extract().response().getBody().asString();
+        assertTrue(responseBody.contains(uniqueCode));
+        params.clear();
+        params.put("uniqueCode", uniqueCode);
+        checkAssignment(url("/WebGoat/WebWolf/landing"), params, true);
+        
+        checkResults("/WebWolf");
+        
+    }
+    
+}

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/XSSTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/XSSTest.java
@@ -39,7 +39,7 @@ public class XSSTest extends IntegrationTest {
         String result =
                 RestAssured.given()
                         .when()
-                        .config(restConfig)
+                        .relaxedHTTPSValidation()
                         .cookie("JSESSIONID", getWebGoatCookie())
                         .header("webgoat-requested-by", "dom-xss-vuln")
                         .header("X-Requested-With", "XMLHttpRequest")

--- a/webgoat-lessons/webwolf-introduction/src/main/java/org/owasp/webgoat/webwolf_introduction/LandingAssignment.java
+++ b/webgoat-lessons/webwolf-introduction/src/main/java/org/owasp/webgoat/webwolf_introduction/LandingAssignment.java
@@ -56,7 +56,7 @@ public class LandingAssignment extends AssignmentEndpoint {
     }
 
 
-    @GetMapping("/password-reset")
+    @GetMapping("/WebWolf/landing/password-reset")
     public ModelAndView openPasswordReset(HttpServletRequest request) throws URISyntaxException {
         URI uri = new URI(request.getRequestURL().toString());
         ModelAndView modelAndView = new ModelAndView();

--- a/webgoat-lessons/webwolf-introduction/src/main/resources/templates/webwolfPasswordReset.html
+++ b/webgoat-lessons/webwolf-introduction/src/main/resources/templates/webwolfPasswordReset.html
@@ -9,7 +9,7 @@
 <div class="container">
     <div class="row">
         <div class="col-xs-12 col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
-            <form role="form" method="POST" th:action="${webwolfUrl}">
+            <form role="form" method="GET" th:action="${webwolfUrl}">
                 <h2 class="sign_up_title">Reset your password</h2>
                 <input type="hidden" name="uniqueCode" th:value="${uniqueCode}"/>
                 <div class="form-group">

--- a/webwolf/pom.xml
+++ b/webwolf/pom.xml
@@ -29,6 +29,11 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/webwolf/src/main/java/org/owasp/webwolf/requests/WebWolfTraceRepository.java
+++ b/webwolf/src/main/java/org/owasp/webwolf/requests/WebWolfTraceRepository.java
@@ -41,7 +41,7 @@ import java.util.List;
 public class WebWolfTraceRepository implements HttpTraceRepository {
 
     private final EvictingQueue<HttpTrace> traces = EvictingQueue.create(10000);
-    private List<String> exclusionList = Lists.newArrayList("/WebWolf/home", "/WebWolf/mail", "/WebWolf/files", "/images/", "/login", "/favicon.ico", "/js/", "/webjars/", "/WebWolf/requests", "/css/", "/mail");
+    private List<String> exclusionList = Lists.newArrayList("/tmpdir", "/WebWolf/home", "/WebWolf/mail", "/WebWolf/files", "/images/", "/login", "/favicon.ico", "/js/", "/webjars/", "/WebWolf/requests", "/css/", "/mail");
 
     @Override
     public List<HttpTrace> findAll() {

--- a/webwolf/src/main/resources/application-webwolf.properties
+++ b/webwolf/src/main/resources/application-webwolf.properties
@@ -18,9 +18,8 @@ logging.level.org.springframework.boot.devtools=WARN
 logging.level.org.owasp=DEBUG
 logging.level.org.owasp.webwolf=TRACE
 
-endpoints.trace.sensitive=false
-management.trace.include=REQUEST_HEADERS,RESPONSE_HEADERS,COOKIES,ERRORS,TIME_TAKEN,PARAMETERS,QUERY_STRING
-endpoints.trace.enabled=true
+management.trace.http.include=REQUEST_HEADERS,RESPONSE_HEADERS,COOKIE_HEADERS,TIME_TAKEN
+management.endpoint.httptrace.enabled=true
 
 spring.thymeleaf.cache=false
 


### PR DESCRIPTION
It seems that Spring Boot 2 upgrade no longer traces POST parameters of HTTP requests. So for the first lesson where that is used, I decided to change the template to use a GET in stead. Also the initial first link was broken. (Results from doing the workshop today) 