### PR TITLE
upgrade ascii doc with support for link in new tab

### DIFF
--- a/webgoat-container/pom.xml
+++ b/webgoat-container/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.5.4</version>
+            <version>1.5.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/OperatingSystemMacro.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/OperatingSystemMacro.java
@@ -12,7 +12,7 @@ public class OperatingSystemMacro extends InlineMacroProcessor {
     }
 
     @Override
-    protected String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+	public String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
         return System.getProperty("os.name");
     }
 }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebGoatTmpDirMacro.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebGoatTmpDirMacro.java
@@ -11,7 +11,7 @@ public class WebGoatTmpDirMacro extends InlineMacroProcessor {
     }
 
     @Override
-    protected String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+	public String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
         return EnvironmentExposure.getEnv().getProperty("webgoat.server.directory");
     }
 }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebGoatVersionMacro.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebGoatVersionMacro.java
@@ -11,7 +11,7 @@ public class WebGoatVersionMacro extends InlineMacroProcessor {
     }
 
     @Override
-    protected String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+	public String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
         return EnvironmentExposure.getEnv().getProperty("webgoat.build.version");
     }
 }

--- a/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebWolfMacro.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebWolfMacro.java
@@ -23,7 +23,7 @@ public class WebWolfMacro extends InlineMacroProcessor {
     }
 
     @Override
-    protected String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+	public String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
         Environment env = EnvironmentExposure.getEnv();
         String hostname = determineHost(env.getProperty("webwolf.host"), env.getProperty("webwolf.port"));
 

--- a/webgoat-lessons/challenge/src/main/resources/html/Challenge1.html
+++ b/webgoat-lessons/challenge/src/main/resources/html/Challenge1.html
@@ -3,6 +3,9 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <div class="lesson-page-wrapper">
+    <div class="adoc-content" th:replace="doc:Challenge_introduction.adoc"></div>
+</div>
+<div class="lesson-page-wrapper">
     <div class="attack-container">
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
 

--- a/webgoat-lessons/challenge/src/main/resources/lessonPlans/en/Challenge_introduction.adoc
+++ b/webgoat-lessons/challenge/src/main/resources/lessonPlans/en/Challenge_introduction.adoc
@@ -4,7 +4,7 @@
 
 The challenges contain more a CTF like lessons where we do not provide any explanations what you need to do, no hints
 will be provided. You can use these challenges in a CTF style where you can run WebGoat on one server and all
-participants can join and hack the challenges. A scoreboard is available at http://localhost:8080/WebGoat/scoreboard
+participants can join and hack the challenges. A scoreboard is available at link:/WebGoat/scoreboard["/WebGoat/scoreboard",window=_blank]
 
 :hardbreaks:
 In this CTF you will need to solve a couple of challenges, each challenge will give you a flag which you will

--- a/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content5b.adoc
+++ b/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content5b.adoc
@@ -5,6 +5,6 @@ You should have been able to execute script with the last example. At this point
 Why is that?
 
 That is because there is no link that would trigger that XSS.
-You can try it yourself to see what happens ... go to (substitute localhost with your server's name or IP if you need to):
+You can try it yourself to see what happens ... go to:
 
-link: http://localhost:8080/WebGoat/CrossSiteScripting/attack5a?QTY1=1&QTY2=1&QTY3=1&QTY4=1&field1=<script>alert('my%20javascript%20here')</script>4128+3214+0002+1999&field2=111
+link:/WebGoat/CrossSiteScripting/attack5a?QTY1=1&QTY2=1&QTY3=1&QTY4=1&field1=<script>alert('my%20javascript%20here')</script>4128+3214+0002+1999&field2=111["/WebGoat/CrossSiteScripting/attack5a?QTY1=1&QTY2=1&QTY3=1&QTY4=1&field1=<script>alert('my%20javascript%20here')</script>4128+3214+0002+1999&field2=111",window=_blank]

--- a/webgoat-lessons/http-proxies/src/main/resources/lessonPlans/en/HttpBasics_ProxyIntro4.adoc
+++ b/webgoat-lessons/http-proxies/src/main/resources/lessonPlans/en/HttpBasics_ProxyIntro4.adoc
@@ -12,8 +12,7 @@ image::images/zap_exclude.png[Select URL from history,style="lesson-image"]
 A new window will open and add the following entries:
 
 ```
-http://localhost:8080/WebGoat/service/.*
-http://localhost:8080/WebGoat/.*.lesson.lesson
+./WebGoat/service/..mvc
 ```
 
 Click Ok to close the window, ZAP will now no longer proxy internal WebGoat requests.


### PR DESCRIPTION
small enhancement for asciidoc. So links can easily be directed to a new tab. 
And added the Challenge page to the first challenge lesson. This was related to the comment on the link to the scoreboard being incorrect (hardcoded to localhost). Now it is a relative link that opens in a separate tab.