### PR TITLE
CSRF lesson fixes and added integration test

### DIFF
--- a/webgoat-container/src/main/java/org/owasp/webgoat/users/UserForm.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/users/UserForm.java
@@ -16,7 +16,7 @@ import javax.validation.constraints.Size;
 public class UserForm {
 
     @NotNull
-    @Size(min=6, max=40)
+    @Size(min=6, max=45)
     @Pattern(regexp = "[a-z0-9-]*", message = "can only contain lowercase letters, digits, and -")
     private String username;
     @NotNull

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/CSRFTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/CSRFTest.java
@@ -1,0 +1,153 @@
+package org.owasp.webgoat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class CSRFTest extends IntegrationTest {
+	
+	private static final String trickHTML3 = "<!DOCTYPE html><html><body><form action=\"WEBGOATURL\" method=\"POST\">\n" + 
+			"<input type=\"hidden\" name=\"csrf\" value=\"thisisnotchecked\"/>\n" + 
+			"<input type=\"submit\" name=\"submit\" value=\"assignment 3\"/>\n" + 
+			"</form></body></html>";
+	
+	private static final String trickHTML4 = "<!DOCTYPE html><html><body><form action=\"WEBGOATURL\" method=\"POST\">\n" + 
+			"<input type=\"hidden\" name=\"reviewText\" value=\"hoi\"/>\n" + 
+			"<input type=\"hidden\" name=\"starts\" value=\"3\"/>\n" + 
+			"<input type=\"hidden\" name=\"validateReq\" value=\"2aa14227b9a13d0bede0388a7fba9aa9\"/>\n" + 
+			"<input type=\"submit\" name=\"submit\" value=\"assignment 4\"/>\n" + 
+			"</form>\n" + 
+			"</body></html>";
+    
+	private static final String trickHTML7 = "<!DOCTYPE html><html><body><form action=\"WEBGOATURL\" enctype='text/plain' method=\"POST\">\n" + 
+			"<input type=\"hidden\" name='{\"name\":\"WebGoat\",\"email\":\"webgoat@webgoat.org\",\"content\":\"WebGoat is the best!!' value='\"}' />\n" + 
+			"<input type=\"submit\" value=\"assignment 7\"/>\n" + 
+			"</form></body></html>";
+	
+    private String webwolfFileDir;
+	
+	
+    @Test
+    public void runTests() throws IOException {
+        startLesson("CSRF");
+        
+        webwolfFileDir = getWebWolfServerPath();
+        
+        //Assignment 3
+        uploadTrickHtml("csrf3.html", trickHTML3.replace("WEBGOATURL", url("/csrf/basic-get-flag")));
+        checkAssignment3(callTrickHtml("csrf3.html"));
+        
+        uploadTrickHtml("csrf4.html", trickHTML4.replace("WEBGOATURL", url("/csrf/review")));
+        checkAssignment4(callTrickHtml("csrf4.html"));
+        
+        uploadTrickHtml("csrf7.html", trickHTML7.replace("WEBGOATURL", url("/csrf/feedback/message")));
+        //checkAssignment7(callTrickHtml("csrf7.html"));
+        
+        //checkResults("/csrf");
+        
+    }
+    
+    private void uploadTrickHtml(String htmlName, String htmlContent) throws IOException {
+    	
+    	//remove any left over html
+    	Path webWolfFilePath = Paths.get(webwolfFileDir);
+        if (webWolfFilePath.resolve(Paths.get(getWebgoatUser(),htmlName)).toFile().exists()) {
+        	Files.delete(webWolfFilePath.resolve(Paths.get(getWebgoatUser(),htmlName)));
+        }
+        
+    	//upload trick html
+        RestAssured.given()
+        .when()
+        .relaxedHTTPSValidation()
+        .cookie("WEBWOLFSESSION", getWebWolfCookie())
+        .multiPart("file", htmlName, htmlContent.getBytes())
+        .post(webWolfUrl("/WebWolf/fileupload"))
+        .then()
+        .extract().response().getBody().asString();
+    }
+    
+    private String callTrickHtml(String htmlName) {
+    	String result = RestAssured.given()
+    	        .when()
+    	        .relaxedHTTPSValidation()
+    	        .cookie("JSESSIONID", getWebGoatCookie())
+    	        .cookie("WEBWOLFSESSION", getWebWolfCookie())
+    	        .get(webWolfUrl("/files/"+getWebgoatUser()+"/"+htmlName))
+    	        .then()
+    	        .extract().response().getBody().asString();
+    	result = result.substring(8+result.indexOf("action=\""));
+    	result = result.substring(0, result.indexOf("\""));
+    	
+    	return result;
+    }
+    
+    private void checkAssignment3(String goatURL) {
+    	
+    	String flag = RestAssured.given()
+            	.when()
+            	.relaxedHTTPSValidation()
+            	.cookie("JSESSIONID", getWebGoatCookie())
+            	.header("Referer", webWolfUrl("/files/fake.html"))
+            	.post(goatURL)
+            	.then()
+            	.extract().path("flag").toString();
+        	
+    	Map<String, Object> params = new HashMap<>();
+        params.clear();
+        params.put("confirmFlagVal", flag);
+        checkAssignment(url("/WebGoat/csrf/confirm-flag-1"), params, true);
+    }
+    
+    private void checkAssignment4(String goatURL) {
+    	
+    	Map<String, Object> params = new HashMap<>();
+        params.clear();
+        params.put("reviewText", "test review");
+        params.put("stars", "5");
+        params.put("validateReq", "2aa14227b9a13d0bede0388a7fba9aa9");//always the same token is the weakness
+    	
+    	boolean result = RestAssured.given()
+            	.when()
+            	.relaxedHTTPSValidation()
+            	.cookie("JSESSIONID", getWebGoatCookie())
+            	.header("Referer", webWolfUrl("/files/fake.html"))
+            	.formParams(params)
+            	.post(goatURL)
+            	.then()
+            	.extract().path("lessonCompleted");
+    	assertEquals(true, result);
+        	
+    }
+    
+    private void checkAssignment7(String goatURL) {
+    	
+    	Map<String, Object> params = new HashMap<>();
+        params.clear();
+        params.put("{\"name\":\"WebGoat\",\"email\":\"webgoat@webgoat.org\",\"content\":\"WebGoat is the best!!", "\"}");
+       
+    	String result = RestAssured.given()
+            	.when()
+            	.relaxedHTTPSValidation()
+            	.cookie("JSESSIONID", getWebGoatCookie())
+            	.header("Referer", webWolfUrl("/files/fake.html"))
+            	.formParams(params)
+            	.log().all()
+            	.contentType(ContentType.TEXT)
+            	.post(goatURL)
+            	.then()
+            	.log().all()
+            	.extract().asString();
+        	
+    }
+    
+}

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/CSRFTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/CSRFTest.java
@@ -186,9 +186,8 @@ public class CSRFTest extends IntegrationTest {
             	.cookie("JSESSIONID", getWebGoatCookie())
             	.header("Referer", webWolfUrl("/files/fake.html"))
             	.params(params)
-            	.log().all()
             	.post(goatURL)            	
-            	.then().log().all()
+            	.then()
             	.extract().cookie("JSESSIONID");
   
     	//select the lesson
@@ -205,10 +204,8 @@ public class CSRFTest extends IntegrationTest {
             	.when()
             	.relaxedHTTPSValidation()
             	.cookie("JSESSIONID", newCookie)
-            	.log().all()
             	.post(url("/csrf/login"))            	
             	.then()
-            	.log().all()
             	.statusCode(200)
             	.extract().path("lessonCompleted");
     	

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/CSRFTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/CSRFTest.java
@@ -47,11 +47,13 @@ public class CSRFTest extends IntegrationTest {
         uploadTrickHtml("csrf3.html", trickHTML3.replace("WEBGOATURL", url("/csrf/basic-get-flag")));
         checkAssignment3(callTrickHtml("csrf3.html"));
         
+        //Assignment 4
         uploadTrickHtml("csrf4.html", trickHTML4.replace("WEBGOATURL", url("/csrf/review")));
         checkAssignment4(callTrickHtml("csrf4.html"));
         
+        //Assignment 7
         uploadTrickHtml("csrf7.html", trickHTML7.replace("WEBGOATURL", url("/csrf/feedback/message")));
-        //checkAssignment7(callTrickHtml("csrf7.html"));
+        checkAssignment7(callTrickHtml("csrf7.html"));
         
         //checkResults("/csrf");
         
@@ -135,18 +137,22 @@ public class CSRFTest extends IntegrationTest {
         params.clear();
         params.put("{\"name\":\"WebGoat\",\"email\":\"webgoat@webgoat.org\",\"content\":\"WebGoat is the best!!", "\"}");
        
-    	String result = RestAssured.given()
+    	String flag = RestAssured.given()
             	.when()
             	.relaxedHTTPSValidation()
             	.cookie("JSESSIONID", getWebGoatCookie())
             	.header("Referer", webWolfUrl("/files/fake.html"))
-            	.formParams(params)
-            	.log().all()
             	.contentType(ContentType.TEXT)
+            	.body("{\"name\":\"WebGoat\",\"email\":\"webgoat@webgoat.org\",\"content\":\"WebGoat is the best!!"+ "=\"}")
             	.post(goatURL)
             	.then()
-            	.log().all()
             	.extract().asString();
+    	flag = flag.substring(9+flag.indexOf("flag is:"));
+    	flag = flag.substring(0, flag.indexOf("\""));
+
+    	params.clear();
+        params.put("confirmFlagVal", flag);
+        checkAssignment(url("/WebGoat/csrf/feedback"), params, true);
         	
     }
     

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
@@ -252,5 +252,33 @@ public abstract class IntegrationTest {
                         .extract().path("lessonCompleted"), CoreMatchers.is(expectedResult));
     }
     
+    public String getWebGoatServerPath() throws IOException {
+    	
+    	//read path from server
+        String result = RestAssured.given()
+        .when()
+        .relaxedHTTPSValidation()
+        .cookie("JSESSIONID", getWebGoatCookie())
+        .get(url("/WebGoat/xxe/tmpdir"))
+        .then()
+        .extract().response().getBody().asString();
+        result = result.replace("%20", " ");
+        return result;
+    }
+    
+    public String getWebWolfServerPath() throws IOException {
+    	
+    	//read path from server
+        String result = RestAssured.given()
+        .when()
+        .relaxedHTTPSValidation()
+        .cookie("WEBWOLFSESSION", getWebWolfCookie())
+        .get(webWolfUrl("/tmpdir"))
+        .then()
+        .extract().response().getBody().asString();
+        result = result.replace("%20", " ");
+        return result;
+    }
+    
 }
 

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/XXETest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/XXETest.java
@@ -81,33 +81,5 @@ public class XXETest extends IntegrationTest {
         result = result.substring(result.lastIndexOf("WebGoat 8.0 rocks... ("),result.lastIndexOf("WebGoat 8.0 rocks... (")+33);
         return result;
     }
-    
-    private String getWebGoatServerPath() throws IOException {
-    	
-    	//read path from server
-        String result = RestAssured.given()
-        .when()
-        .relaxedHTTPSValidation()
-        .cookie("JSESSIONID", getWebGoatCookie())
-        .get(url("/WebGoat/xxe/tmpdir"))
-        .then()
-        .extract().response().getBody().asString();
-        result = result.replace("%20", " ");
-        return result;
-    }
-    
-    private String getWebWolfServerPath() throws IOException {
-    	
-    	//read path from server
-        String result = RestAssured.given()
-        .when()
-        .relaxedHTTPSValidation()
-        .cookie("WEBWOLFSESSION", getWebWolfCookie())
-        .get(webWolfUrl("/tmpdir"))
-        .then()
-        .extract().response().getBody().asString();
-        result = result.replace("%20", " ");
-        return result;
-    }
         
 }

--- a/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/csrf/CSRFFeedback.java
+++ b/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/csrf/CSRFFeedback.java
@@ -68,7 +68,7 @@ public class CSRFFeedback extends AssignmentEndpoint {
         } catch (IOException e) {
             return failed().feedback(ExceptionUtils.getStackTrace(e)).build();
         }
-        boolean correctCSRF = requestContainsWebGoatCookie(request.getCookies()) && request.getContentType().equals(MediaType.TEXT_PLAIN_VALUE);
+        boolean correctCSRF = requestContainsWebGoatCookie(request.getCookies()) && request.getContentType().contains(MediaType.TEXT_PLAIN_VALUE);
         correctCSRF &= hostOrRefererDifferentHost(request);
         if (correctCSRF) {
             String flag = UUID.randomUUID().toString();
@@ -89,8 +89,8 @@ public class CSRFFeedback extends AssignmentEndpoint {
     }
 
     private boolean hostOrRefererDifferentHost(HttpServletRequest request) {
-        String referer = request.getHeader("referer");
-        String host = request.getHeader("host");
+        String referer = request.getHeader("Referer");
+        String host = request.getHeader("Host");
         if (referer != null) {
             return !referer.contains(host);
         } else {

--- a/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/csrf/CSRFGetFlag.java
+++ b/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/csrf/CSRFGetFlag.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -40,7 +41,7 @@ import java.util.Random;
 /**
  * Created by jason on 9/30/17.
  */
-
+@RestController
 public class CSRFGetFlag {
 
     @Autowired
@@ -48,7 +49,7 @@ public class CSRFGetFlag {
     @Autowired
     private PluginMessages pluginMessages;
 
-    @RequestMapping(produces = {"application/json"}, method = RequestMethod.POST)
+    @RequestMapping(path="/csrf/basic-get-flag" ,produces = {"application/json"}, method = RequestMethod.POST)
     @ResponseBody
     public Map<String, Object> invoke(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 

--- a/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/csrf/CSRFLogin.java
+++ b/webgoat-lessons/csrf/src/main/java/org/owasp/webgoat/csrf/CSRFLogin.java
@@ -22,9 +22,10 @@
 
 package org.owasp.webgoat.csrf;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.owasp.webgoat.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.assignments.AssignmentHints;
-import org.owasp.webgoat.assignments.AssignmentPath;
 import org.owasp.webgoat.assignments.AttackResult;
 import org.owasp.webgoat.users.UserTracker;
 import org.owasp.webgoat.users.UserTrackerRepository;
@@ -46,8 +47,8 @@ public class CSRFLogin extends AssignmentEndpoint {
 
     @PostMapping(path = "/csrf/login", produces = {"application/json"})
     @ResponseBody
-    public AttackResult completed() {
-        String userName = getWebSession().getUserName();
+    public AttackResult completed(HttpServletRequest request) {
+        String userName = request.getUserPrincipal().getName();
         if (userName.startsWith("csrf")) {
             markAssignmentSolvedWithRealUser(userName.substring("csrf-".length()));
             return trackProgress(success().feedback("csrf-login-success").build());

--- a/webgoat-lessons/csrf/src/main/resources/html/CSRF.html
+++ b/webgoat-lessons/csrf/src/main/resources/html/CSRF.html
@@ -139,7 +139,7 @@
   padding: 7px;
   margin-top:7px;
   padding:5px;">
-        <div class="attack-container">
+        <div class="example-container">
             <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
             <div class="container-fluid">
                 <div class="row">


### PR DESCRIPTION
Some parts of the lesson were broken. The 8th assignment is also a bit strange. Part of the data in the session is moved to the new session. The web goat user data is then no longer in sync with the actual user principal of the request. For the lesson I now check on the user principal which is more correct anyway. But maybe something to look at. All CSRF lessons are ok now.
The length of the username had to be enlarged due to the csrf-...... uuid length.