### PR TITLE
Broken IDOR lesson due to lost URL

### DIFF
--- a/webgoat-lessons/idor/src/main/java/org/owasp/webgoat/idor/IDORViewOwnProfile.java
+++ b/webgoat-lessons/idor/src/main/java/org/owasp/webgoat/idor/IDORViewOwnProfile.java
@@ -36,7 +36,7 @@ public class IDORViewOwnProfile {
     @Autowired
     UserSessionData userSessionData;
 
-    @GetMapping(path = "IDOR/own", produces = {"application/json"})
+    @GetMapping(path = {"IDOR/own", "IDOR/profile"}, produces = {"application/json"})
     @ResponseBody
     public Map<String, Object> invoke() {
         Map<String,Object> details = new HashMap<>();


### PR DESCRIPTION
In the migration to Spring 2, this method lost its get mapping to the… IDOR/profile url,breaking the javascript call to that address.