### PR TITLE
Solves issue 725

### DIFF
--- a/webgoat-lessons/pom.xml
+++ b/webgoat-lessons/pom.xml
@@ -90,11 +90,10 @@
             <artifactId>zxcvbn</artifactId>
             <version>1.2.5</version>
         </dependency>
-        <!-- Temporarily -->
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.7</version>
+            <version>1.4.5</version>
         </dependency>
     </dependencies>
     <dependencyManagement>


### PR DESCRIPTION
This lesson is intended to show the dangers of outdated dependencies. However in version 1.4.7 of xstream, the vulnerability is fixed! In 1.4.5 it is still present, so I suggest this downgrade. It is tested and works as intended, just as 1.4.7 does not.