### PR TITLE
Hostname through proxy and docker

### DIFF
--- a/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebWolfMacro.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/asciidoc/WebWolfMacro.java
@@ -38,14 +38,23 @@ public class WebWolfMacro extends InlineMacroProcessor {
     }
 
     /**
-     * Look at the remote address from received from the browser first. This way it will also work if you run
-     * the browser in a Docker container and WebGoat on your local machine.
+     * Determine the host from the hostname and ports that were used. 
+     * The purpose is to make it possible to use the application behind a reverse proxy. For instance in the docker
+     * compose/stack version with webgoat webwolf and nginx proxy. 
+     * You do not have to use the indicated hostname, but if you do, you should define two hosts aliases
+     * 127.0.0.1 www.webgoat.local www.webwolf.locaal
      */
     private String determineHost(String host, String port) {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        String ip = request.getRemoteAddr();
-        String hostname = StringUtils.hasText(ip) ? ip : host;
-        return "http://" + hostname + ":" + port + (includeWebWolfContext() ? "/WebWolf" : "");
+        host = request.getHeader("Host");
+        int semicolonIndex = host.indexOf(":");
+        if (semicolonIndex==-1 || host.endsWith(":80")) {
+        	host = host.replace(":80", "").replace("www.webgoat.local", "www.webwolf.local");
+        } else {
+        	host = host.substring(0, semicolonIndex);
+        	host = host.concat(":").concat(port);
+        }
+        return "http://" + host + (includeWebWolfContext() ? "/WebWolf" : "");
     }
 
     protected boolean includeWebWolfContext() {

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
@@ -189,7 +189,6 @@ public abstract class IntegrationTest {
                         .formParams(params)
                         .post(url)
                         .then()
-                        .log().all()
                         .statusCode(200)
                         .extract().path("lessonCompleted"), CoreMatchers.is(expectedResult));
     }

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/IntegrationTest.java
@@ -22,8 +22,19 @@ public abstract class IntegrationTest {
 
     protected static int WG_PORT = 8080;
     protected static int WW_PORT = 9090;
-    private static String WEBGOAT_URL = "http://127.0.0.1:" + WG_PORT + "/WebGoat/";
-    private static String WEBWOLF_URL = "http://127.0.0.1:" + WW_PORT + "/";
+    private static String WEBGOAT_HOSTNAME = "127.0.0.1";//"www.webgoat.local";
+    private static String WEBWOLF_HOSTNAME = "127.0.0.1";//"www.webwolf.local";
+    
+    /*
+     * To test docker compose/stack solution: 
+     * add localhost settings in hosts file: 127.0.0.1 www.webgoat.local www.webwolf.local
+     * Then set the above values to the specified host names and set the port to 80
+     */
+    
+    private static String WEBGOAT_HOSTHEADER = WEBGOAT_HOSTNAME +":"+WG_PORT;
+    private static String WEBWOLF_HOSTHEADER = WEBWOLF_HOSTNAME +":"+WW_PORT;
+    private static String WEBGOAT_URL = "http://" + WEBGOAT_HOSTHEADER + "/WebGoat/";
+    private static String WEBWOLF_URL = "http://" + WEBWOLF_HOSTHEADER + "/";
     private static boolean WG_SSL = false;//enable this if you want to run the test on ssl
 
     @Getter
@@ -178,6 +189,7 @@ public abstract class IntegrationTest {
                         .formParams(params)
                         .post(url)
                         .then()
+                        .log().all()
                         .statusCode(200)
                         .extract().path("lessonCompleted"), CoreMatchers.is(expectedResult));
     }
@@ -276,6 +288,14 @@ public abstract class IntegrationTest {
                 .extract().response().getBody().asString();
         result = result.replace("%20", " ");
         return result;
+    }
+    
+    /**
+     * In order to facilitate tests with 
+     * @return
+     */
+    public String getWebWolfHostHeader() {
+    	return WEBWOLF_HOSTHEADER;
     }
 
 }

--- a/webgoat-integration-tests/src/test/java/org/owasp/webgoat/PasswordResetLessonTest.java
+++ b/webgoat-integration-tests/src/test/java/org/owasp/webgoat/PasswordResetLessonTest.java
@@ -46,6 +46,7 @@ public class PasswordResetLessonTest extends IntegrationTest {
                 .formParams("resetLink", link, "password", "123456")
                 .post(url("PasswordReset/reset/change-password"))
                 .then()
+                .log().all()
                 .statusCode(200);
     }
 
@@ -56,6 +57,7 @@ public class PasswordResetLessonTest extends IntegrationTest {
                 .cookie("WEBWOLFSESSION", getWebWolfCookie())
                 .get(webWolfUrl("WebWolf/requests"))
                 .then()
+                .log().all()
                 .extract().response().getBody().asString();
         int startIndex = responseBody.lastIndexOf("/PasswordReset/reset/reset-password/");
         var link = responseBody.substring(startIndex + "/PasswordReset/reset/reset-password/".length(), responseBody.indexOf(",", startIndex) - 1);
@@ -65,7 +67,7 @@ public class PasswordResetLessonTest extends IntegrationTest {
     private void clickForgotEmailLink(String user) {
         RestAssured.given()
                 .when()
-                .header("host", "localhost:9090")
+                .header("host", getWebWolfHostHeader())
                 .relaxedHTTPSValidation()
                 .cookie("JSESSIONID", getWebGoatCookie())
                 .formParams("email", user)

--- a/webgoat-lessons/password-reset/src/main/java/org/owasp/webgoat/password_reset/ResetLinkAssignmentForgotPassword.java
+++ b/webgoat-lessons/password-reset/src/main/java/org/owasp/webgoat/password_reset/ResetLinkAssignmentForgotPassword.java
@@ -61,7 +61,7 @@ public class ResetLinkAssignmentForgotPassword extends AssignmentEndpoint {
         ResetLinkAssignment.resetLinks.add(resetLink);
         String host = request.getHeader("host");
         if (hasText(email)) {
-            if (email.equals(ResetLinkAssignment.TOM_EMAIL) && host.contains("9090")) { //User indeed changed the host header.
+            if (email.equals(ResetLinkAssignment.TOM_EMAIL) && (host.contains("9090")||host.contains("webwolf"))) { //User indeed changed the host header.
                 ResetLinkAssignment.userToTomResetLink.put(getWebSession().getUserName(), resetLink);
                 fakeClickingLinkEmail(host, resetLink);
             } else {


### PR DESCRIPTION
I have made a few small changes to support the use of running webgoat and webwolf in a docker stack/compose way. It still works standalone as well and in normal docker containers.

See #731 related issue. I ran all the integration tests on the a docker image from the build in this branch. I can deliver the goat.yml docker stack/compose file once these changes are on the develop branch and a release has been made, so I can refer to a webgoat image with the required fixes.

The docker swarm yel can be found here: https://github.com/zubcevic/webgoat-training/tree/master/docker-swarm

In this yaml a timezone is added so the Deserialization exercise can be made successful. And hostnames are defined so that the XXE and password reset calls from the goat container to the web wolf container are reachable as well. And are still based on the hosts names defined.

The reverseproxy image is already pushed to docker hub and the build file can be found here:
https://github.com/zubcevic/webgoat-training/tree/master/nginx

The yaml and related deployment instructions can be added to the repository at a later stage