### PR TITLE
dockerfile and compose changes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,8 +4,8 @@
 [![Coverage Status](https://coveralls.io/repos/WebGoat/WebGoat/badge.svg?branch=develop&service=github)](https://coveralls.io/github/WebGoat/WebGoat?branch=master)
 [![Codacy Badge](https://api.codacy.com/project/badge/b69ee3a86e3b4afcaf993f210fccfb1d)](https://www.codacy.com/app/dm/WebGoat)
 [![Dependency Status](https://www.versioneye.com/user/projects/562da95ae346d7000e0369aa/badge.svg?style=flat)](https://www.versioneye.com/user/projects/562da95ae346d7000e0369aa)
-[![OWASP Labs](https://img.shields.io/badge/owasp-lab%20project-f7b73c.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Labs_Projects) 
-[![GitHub release](https://img.shields.io/github/release/WebGoat/WebGoat.svg)](https://github.com/WebGoat/WebGoat/releases/latest) 
+[![OWASP Labs](https://img.shields.io/badge/owasp-lab%20project-f7b73c.svg)](https://www.owasp.org/index.php/OWASP_Project_Inventory#tab=Labs_Projects)
+[![GitHub release](https://img.shields.io/github/release/WebGoat/WebGoat.svg)](https://github.com/WebGoat/WebGoat/releases/latest)
 
 # Introduction
 
@@ -29,7 +29,7 @@ first thing that all hackers claim.*
 
 # Installation Instructions:
 
-## 1. Standalone 
+## 1. Standalone
 
 Download the latest WebGoat release from [https://github.com/WebGoat/WebGoat/releases](https://github.com/WebGoat/WebGoat/releases)
 
@@ -45,19 +45,42 @@ can bind it to a different address (default localhost)
 
 Every release is also published on [DockerHub]((https://hub.docker.com/r/webgoat/webgoat-8.0/)).
 
-### Using docker-compose
+### Using docker run
 
-The easiest way to start WebGoat as a Docker container is to use the `docker-compose.yml` [file](https://raw.githubusercontent.com/WebGoat/WebGoat/develop/docker-compose.yml) 
-from our Github repository. This will start both containers and it also takes care of setting up the
-connection between WebGoat and WebWolf.
+The easiest way to start WebGoat as a Docker container is to use the all-in-one docker container. This is a docker image that has WebGoat and WebWolf running inside.
 
 ```shell
-curl https://raw.githubusercontent.com/WebGoat/WebGoat/develop/docker-compose.yml | docker-compose -f - up
+docker run -d -p 8080:8080 -p 9090:9090 -e TZ=Europe/Amsterdam webgoat/goatandwolf
 ```
 
-**Important**: the current directory on your host will be mapped into the container for keeping state.
+WebGoat will be located at: http://127.0.0.1:8080/WebGoat
+WebWolf will be located at: http://127.0.0.1:9090/WebWolf
 
-Using the `docker-compose` file will simplify getting WebGoat and WebWolf up and running.
+**Important**: Choose the correct timezone, so that the docker container and your host are in the same timezone. As it important for the validity of JWT tokens used in certain exercises.
+
+### Using docker stack deploy
+
+Another way to deply WebGoat and WebWolf in a more advanced way is to use a compose-file in a docker stack deploy.
+You can define which containers should run in which combinations and define all of this in a yaml file.
+An example of such a file is: `goat-with-reverseproxy.yaml` [file](https://raw.githubusercontent.com/WebGoat/WebGoat/develop/goat-with-reverseproxy.yaml)
+This sets up an nginx webserver as reverse proxy to WebGoat and WebWolf.
+
+```shell
+docker stack init
+docker stack deploy --compose-file goat-with-reverseproxy.yaml webgoatdemo
+```
+
+Add the following entries in your local hosts file:
+
+```shell
+127.0.0.1 www.webgoat.local www.webwolf.localhost
+```
+
+You can use the overall start page: http://www.webgoat.local or:
+WebGoat will be located at: http://www.webgoat.local/WebGoat
+WebWolf will be located at: http://www.webwolf.local/WebWolf
+
+**Important**: the current directory on your host will be mapped into the container for keeping state.
 
 
 ## 3. Run from the sources

--- a/README.MD
+++ b/README.MD
@@ -62,8 +62,9 @@ WebWolf will be located at: http://127.0.0.1:9090/WebWolf
 
 Another way to deply WebGoat and WebWolf in a more advanced way is to use a compose-file in a docker stack deploy.
 You can define which containers should run in which combinations and define all of this in a yaml file.
-An example of such a file is: `goat-with-reverseproxy.yaml` [file](https://raw.githubusercontent.com/WebGoat/WebGoat/develop/goat-with-reverseproxy.yaml)
-This sets up an nginx webserver as reverse proxy to WebGoat and WebWolf.
+An example of such a file is: [goat-with-reverseproxy.yaml](goat-with-reverseproxy.yaml)
+
+This sets up an nginx webserver as reverse proxy to WebGoat and WebWolf. You can change the timezone by adjusting the value in the yaml file.
 
 ```shell
 docker stack init
@@ -77,7 +78,9 @@ Add the following entries in your local hosts file:
 ```
 
 You can use the overall start page: http://www.webgoat.local or:
+
 WebGoat will be located at: http://www.webgoat.local/WebGoat
+
 WebWolf will be located at: http://www.webwolf.local/WebWolf
 
 **Important**: the current directory on your host will be mapped into the container for keeping state.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3'
 
 services:
   webgoat:
@@ -6,13 +6,17 @@ services:
     environment:
       - WEBWOLF_HOST=webwolf
       - WEBWOLF_PORT=9090
+      - TZ=Europe/Amsterdam
     ports:
       - "8080:8080"
       - "9001:9001"
     volumes:
       - .:/home/webgoat/.webgoat
+    working_dir: /home/webgoat
   webwolf:
     image: webgoat/webwolf
     ports:
       - "9090:9090"
     command: --spring.datasource.url=jdbc:hsqldb:hsql://webgoat:9001/webgoat --server.address=0.0.0.0
+    depends_on:
+            - webgoat

--- a/goat-with-reverseproxy.yaml
+++ b/goat-with-reverseproxy.yaml
@@ -1,0 +1,43 @@
+version: '3'
+networks:
+  webwolflocal:
+services:
+  webgoat:
+    hostname: www.webgoat.local
+    image: webgoat/webgoat-8.0
+    environment:
+      - WEBGOAT_PORT=8080
+      - WEBGOAT_SSLENABLED=false
+      - WEBWOLF_HOST=webwolf
+      - WEBWOLF_PORT=9090
+      - TZ=Europe/Amsterdam
+    volumes:
+      - .:/home/webgoat/.webgoat
+    working_dir: /home/webgoat
+    command: --server.address=0.0.0.0
+    networks:
+      webwolflocal:
+        aliases:
+          - goat.webgoat.local
+  webwolf:
+    image: webgoat/webwolf
+    environment:
+      - WEBWOLF_HOST=webwolf
+      - WEBWOLF_PORT=9090
+      - TZ=Europe/Amsterdam
+    command: --spring.datasource.url=jdbc:hsqldb:hsql://webgoat:9001/webgoat --server.address=0.0.0.0
+    networks:
+      webwolflocal:
+        aliases:
+          - wolf.webwolf.local
+    depends_on:
+            - webgoat
+  reverseproxy:
+    hostname: www.webwolf.local
+    image: webgoat/reverseproxy
+    networks:
+      webwolflocal:
+        aliases:
+          - www.webwolf.local
+    ports:
+      - 80:80

--- a/webgoat-server/Dockerfile
+++ b/webgoat-server/Dockerfile
@@ -12,5 +12,6 @@ COPY target/webgoat-server-${webgoat_version}.jar /home/webgoat/webgoat.jar
 
 EXPOSE 8080
 
+WORKDIR /home/webgoat
 ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/home/webgoat/webgoat.jar"]
 CMD ["--server.port=8080", "--server.address=0.0.0.0"]


### PR DESCRIPTION
Changes to the Readme. It proposes to use the all in one docker image. This still needs to be part of the release process, but at least one image is pushed to web goat/goatandwolf repository. It solved the issue with the working directory and the timezone issue.

It also includes the advanced docker stack deploy example where you would be able to use it with fake hostsnames and port 80 through a reverse proxy. Which will become available after we push the latest working image to webgoat/webgoat-8.0 repo.