### PR TITLE
add support for status 403 feedback from e.g. ModSecurity/CRS

### DIFF
--- a/webgoat-container/src/main/resources/static/js/goatApp/view/LessonContentView.js
+++ b/webgoat-container/src/main/resources/static/js/goatApp/view/LessonContentView.js
@@ -113,12 +113,16 @@ define(['jquery',
                 //complete: function (data) {
                     //callbackFunction(data);
                 //}
-            }).then(function(data){
-                 self.onSuccessResponse(data, failureCallbackFunctionName, successCallBackFunctionName)}, self.onErrorResponse.bind(self));
+            }).then(
+            		function(data){
+                 self.onSuccessResponse(data, failureCallbackFunctionName, successCallBackFunctionName)
+                 }, 
+                 self.onErrorResponse.bind(self)
+                 );
             return false;
          },
 
-        onSuccessResponse: function(data, failureCallbackFunctionName, successCallBackFunctionName) {
+        onSuccessResponse: function(data, failureCallbackFunctionName, successCallBackFunctionName) {        	
             this.renderFeedback(data.feedback);
             this.renderOutput(data.output || "");
 
@@ -147,10 +151,15 @@ define(['jquery',
             $(this.curForm).siblings('.assignment-success').find('i').addClass('hidden');
         },
 
-        onErrorResponse: function (a,b,c) {
-            console.error(a);
+        onErrorResponse: function (data,b,c) {
+        	console.error(data);
+        	if (data.status == 403) {
+        		this.renderFeedback(data.responseText);
+        	}
+            
             console.error(b);
             console.error(c);
+            
             return false;
         },
 


### PR DESCRIPTION
With this small change in the javascript, a 403 return on a challenge will be shown in the feedback section. This is useful/necessary if for demo purposes, you want to show the effect of a web application firewall protecting your insecure web app. You might want to challenge people if they can still misuse the vulnerability in these situations.
<img width="965" alt="Schermafbeelding 2020-02-21 om 12 49 19" src="https://user-images.githubusercontent.com/7931455/75032794-ba4c7300-54a9-11ea-8697-c82e9283c3cf.png">
