### PR TITLE
corrected hints and improved error handling base64

### DIFF
--- a/webgoat-lessons/crypto/src/main/java/org/owasp/webgoat/crypto/CryptoUtil.java
+++ b/webgoat-lessons/crypto/src/main/java/org/owasp/webgoat/crypto/CryptoUtil.java
@@ -16,7 +16,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Base64;
-import java.util.Random;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -74,12 +73,15 @@ public class CryptoUtil {
 			PublicKey publicKey) {
 
 		log.debug("start verifyMessage");
-
-		//get raw signature from base64 encrypted string in header
-		byte[] decodedSignature = Base64.getDecoder().decode(base64EncSignature);
 		boolean result = false;
 		
 		try {
+			
+			base64EncSignature = base64EncSignature.replace("\r", "").replace("\n", "")
+					.replace(" ", "");
+			//get raw signature from base64 encrypted string in header
+			byte[] decodedSignature = Base64.getDecoder().decode(base64EncSignature);
+			
 			//Initiate signature verification
 			Signature instance = Signature.getInstance("SHA256withRSA");
 			instance.initVerify(publicKey);

--- a/webgoat-lessons/crypto/src/main/resources/i18n/WebGoatLabels.properties
+++ b/webgoat-lessons/crypto/src/main/resources/i18n/WebGoatLabels.properties
@@ -12,8 +12,8 @@ crypto-hashing.hints.2=Find a online hash database or just google on the hash it
 
 crypto-signing.hints.1=Use openssl to get the public key from the private key. Apparently both private and public key information are stored.
 crypto-signing.hints.2=Use the private key to sign the "modulus" value of the public key.
-crypto-signing.hints.3=Actually the "modulus" of the public key is the same as the private key. You could use openssl -in test.key -pubout > test.pub and then openssl -in test.pub -pubin -modulus or other components. 
-crypto-signing.hints.4=Make sure that you do not take hidden characters into account. You might want to use echo -n "00AE89..." | openssl dgst -sign ...
+crypto-signing.hints.3=Actually the "modulus" of the public key is the same as the private key. You could use openssl rsa -in test.key -pubout > test.pub and then openssl rsa -in test.pub -pubin -modulus -noout or other components. 
+crypto-signing.hints.4=Make sure that you do not take hidden characters into account. You might want to use echo -n "00AE89..." | openssl dgst -sign somekey -sha256 ... and do not forget to base64 encode the outcome
  
 
 crypto-signing.notok=The signature does not match the data (modulus)


### PR DESCRIPTION
While checking the lesson, I noticed some lack of info in the hints and also saw that base64 with some linefeeds or spaces were not excepted without giving proper feedback