### PR TITLE
lessonplan character updates so it also works on Windows Cp125

### DIFF
--- a/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content3.adoc
+++ b/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content3.adoc
@@ -4,15 +4,15 @@
 * Stealing session cookies
 * Creating false requests
 * Creating false fields on a page to collect credentials
-* Redirecting your page to a “non-friendly” site
+* Redirecting your page to a "non-friendly" site
 * Creating requests that masquerade as a valid user
 * Stealing of confidential information
 * Execution of malicious code on an end-user system (active scripting)
 * Insertion of hostile and inappropriate content
 +
 ----
-<img src=“http://malicious.site.com/image.jpg/>
-“>GoodYear recommends buying BridgeStone tires…
+<img src="http://malicious.site.com/image.jpg/>
+">GoodYear recommends buying BridgeStone tires...
 ----
 
 === XSS attacks add validity to phishing attacks

--- a/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content6.adoc
+++ b/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_content6.adoc
@@ -9,6 +9,6 @@ The difference between DOM and 'traditional' reflected XSS is that, with DOM, th
 * That link may load a malicious web page or a web page they use (are logged into?) that has a vulnerable route/handler
 * If it's a  malicious web page, it may use it's own JavaScript to attack another page/url with a vulnerable route/handler
 * The vulnerable page renders the payload and executes attack in the user's context on that page/site
-* Attacker’s malicious script may run commands with the privileges of local account
+* Attacker's malicious script may run commands with the privileges of local account
 
 *Victim does not realize attack occurred* ... Malicious attackers don't use &lt;script&gt;alert('xss')&lt;/ script&gt;

--- a/webgoat-lessons/csrf/src/main/resources/lessonPlans/en/CSRF_Login.adoc
+++ b/webgoat-lessons/csrf/src/main/resources/lessonPlans/en/CSRF_Login.adoc
@@ -5,8 +5,8 @@
 In a login CSRF attack, the attacker forges a login request to an honest site using the attacker’s username 
 and password at that site. If the forgery succeeds, the honest server responds with a `Set-Cookie` header 
 that instructs the browser to mutate its state by storing a session cookie, logging the user into
-the honest site as the attacker. This session cookie is used to bind subsequent requests to the user’s session and hence
-to the attacker’s authentication credentials. Login CSRF attacks can have serious consequences, for example 
+the honest site as the attacker. This session cookie is used to bind subsequent requests to the user's session and hence
+to the attacker's authentication credentials. Login CSRF attacks can have serious consequences, for example 
 see the picture below where an attacker created an account at google.com the victim visits the malicious
 website and the user is logged in as the attacker. The attacker could then later on gather information about
 the activities of the user.

--- a/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content10.adoc
+++ b/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content10.adoc
@@ -1,4 +1,4 @@
-== Parameterized Queries – Java Example
+== Parameterized Queries - Java Example
 [source,java]
 -------------------------------------------------------
 public static String loadAccount() {
@@ -15,10 +15,10 @@ public static String loadAccount() {
        if (results.getRow() <= 2) {
          data = processAccount(results);
        } else {
-         // Handle the error – Database integrity issue
+         // Handle the error - Database integrity issue
        }
      } else {
-       // Handle the error – no records found }
+       // Handle the error - no records found }
      }
   } catch (SQLException sqle) {
     // Log and handle the SQL Exception }

--- a/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content11.adoc
+++ b/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content11.adoc
@@ -1,7 +1,7 @@
-== Parameterized Queries – .NET
+== Parameterized Queries - .NET
 -------------------------------------------------------
 public static bool isUsernameValid(string username) {
-	RegEx r = new Regex(“^[A-Za-z0-9]{16}$”);
+	RegEx r = new Regex("^[A-Za-z0-9]{16}$");
 	Return r.isMatch(username);
 }
 
@@ -18,5 +18,5 @@ try {
 		}
 	} else { // handle invalid input }
 }
-catch (Exception e) { // Handle all exceptions… }
+catch (Exception e) { // Handle all exceptions... }
 -------------------------------------------------------

--- a/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content12.adoc
+++ b/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content12.adoc
@@ -6,7 +6,7 @@
 === Prevents other types of attacks from being stored in the database
 * Stored XSS
 * Information leakage
-* Logic errors – business rule validation
+* Logic errors - business rule validation
 * SQL injection
 
 === Often the database is considered trusted

--- a/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content9.adoc
+++ b/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content9.adoc
@@ -1,4 +1,4 @@
-== Parameterized Queries – Java Snippet
+== Parameterized Queries - Java Snippet
 [source,java]
 ----
 public static bool isUsernameValid(string username) {
@@ -21,5 +21,5 @@ try {
         }
     } else { // handle invalid input }
 }
-catch (…) { // handle all exceptions … }
+catch (...) { // handle all exceptions ... }
 ----

--- a/webgoat-lessons/webgoat-introduction/src/main/resources/lessonPlans/en/Introduction.adoc
+++ b/webgoat-lessons/webgoat-introduction/src/main/resources/lessonPlans/en/Introduction.adoc
@@ -10,7 +10,7 @@ unintended code gets into your applications.
 
 What better way to do that than with your very own scapegoat?
 
-Feel free to do what you will with him. Hack, poke, prod and if it makes you feel better, scare him until your heart’s content.
+Feel free to do what you will with him. Hack, poke, prod and if it makes you feel better, scare him until your heart's content.
 Go ahead, and hack the goat. We promise he likes it.
 
 Thanks for your interest!


### PR DESCRIPTION
On windows all characters would be normal with the -Dfile.encoding=UTF-8, but just to support or prevent reports on issues with Cp1252, some characters have been replaced so they will be ok in Cp1252 as well.