### PR TITLE
1 poller disabled and 1 change to every minute

### DIFF
--- a/webgoat-container/src/main/resources/static/js/goatApp/model/MenuCollection.js
+++ b/webgoat-container/src/main/resources/static/js/goatApp/model/MenuCollection.js
@@ -11,9 +11,10 @@ define(['jquery',
             initialize: function () {
                 var self = this;
                 this.fetch();
+                //RZ not completely removed, but for now changed to once every minute. after each assignment the menu and content are always updated anyway
                 setInterval(function () {
                     this.fetch()
-                }.bind(this), 5000);
+                }.bind(this), 60000);
             },
 
             onDataLoaded: function () {

--- a/webgoat-container/src/main/resources/static/js/goatApp/view/LessonContentView.js
+++ b/webgoat-container/src/main/resources/static/js/goatApp/view/LessonContentView.js
@@ -25,9 +25,10 @@ define(['jquery',
                         self.navToPage(page);
                     }
                 });
-                setInterval(function () {
-                    this.updatePagination();
-                }.bind(this), 5000);
+                //RZ: disabled as it is not really needed
+                //setInterval(function () {
+                  //  this.updatePagination();
+                //}.bind(this), 5000);
             },
 
             findPage: function (assignment) {


### PR DESCRIPTION
This pull request is about whether or not we need the polling mechanism. I cannot really see a good reason to use it, so I think we can disable it. So i disabled one and set the other to every minute in stead of every 5s. Normal use of the lessons and assignments seems still ok as after every assignment both lessonmenu and lessonoverview are still called.
Only when you do a edit and resend from the browser or zap history, you will only see the updated buttons after a refresh.
Or were there other reasons? 
#809 