### PR TITLE
Password reset lesson related cleanup

### DIFF
--- a/webgoat-lessons/password-reset/src/main/resources/lessonPlans/en/PasswordReset_SecurityQuestions.adoc
+++ b/webgoat-lessons/password-reset/src/main/resources/lessonPlans/en/PasswordReset_SecurityQuestions.adoc
@@ -1,6 +1,6 @@
 == The Problem with Security Questions
 
-While Security Questions my at first seem like a good way to do authentication, they
+While Security Questions may at first seem like a good way to do authentication, they
 have some big problems.
 
 The "perfect" security question should be hard to crack, but easy to remember. Also the answer needs to fixed,

--- a/webgoat-lessons/password-reset/src/main/resources/lessonPlans/en/PasswordReset_host_header.adoc
+++ b/webgoat-lessons/password-reset/src/main/resources/lessonPlans/en/PasswordReset_host_header.adoc
@@ -6,8 +6,8 @@ When creating a password reset link you need to make sure:
 - It can only be used once
 - The link is only valid for a limited amount of time.
 
-Send a link with a random token means an attacker cannot start a simple DOS attack to your website by starting to
-block users. The link should not be used more than once which makes it impossible to change the password again.
+Sending a link with a random token means an attacker cannot start a simple DOS attack to your website by starting to
+block users. The link should not be usable more than once which makes it impossible to change the password again.
 The time out is necessary to restrict the attack window, having a link opens up a lot of possibilities for the attacker.
 
 == Assignment

--- a/webgoat-lessons/password-reset/src/main/resources/lessonPlans/en/PasswordReset_password_reset_link.adoc
+++ b/webgoat-lessons/password-reset/src/main/resources/lessonPlans/en/PasswordReset_password_reset_link.adoc
@@ -1,3 +1,0 @@
-== Password reset link
-
-Should be unique, do


### PR DESCRIPTION
Fixes spelling issues in PasswordReset_SecurityQuestions.adoc and PasswordReset_host_header.adoc.  Also removes unused file 'PasswordReset_password_reset_link.adoc". 