### PR TITLE
XSS Quiz: Fix 404

### DIFF
--- a/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_quiz.adoc
+++ b/webgoat-lessons/cross-site-scripting/src/main/resources/lessonPlans/en/CrossSiteScripting_quiz.adoc
@@ -1,1 +1,1 @@
-Now it is time for a quiz! It is recommended to check the OWASP Cross-Site Scripting explanations https://www.owasp.org/index.php/Cross-site_Scripting_(XSS) . Answer all questions correctly to complete the assignment.
+Now it is time for a quiz! It is recommended to check the OWASP Cross-Site Scripting explanations https://owasp.org/www-community/attacks/xss/. Answer all questions correctly to complete the assignment.


### PR DESCRIPTION
The original URL was malformed because it contained a closing ) which did not end up in the link. However the corrected link performs a redirect to the link provided in this patch.