### PR TITLE
Fix a typo in 1proxysetupsteps.adoc

### DIFF
--- a/webgoat-lessons/http-proxies/src/main/resources/lessonPlans/en/1proxysetupsteps.adoc
+++ b/webgoat-lessons/http-proxies/src/main/resources/lessonPlans/en/1proxysetupsteps.adoc
@@ -8,6 +8,6 @@ Since this is an OWASP project, we'll be using OWASP ZAP. If you are comfortable
 * First download and install ZAP 2.8.0 for your operating system
 * Start ZAP 
 * Configure the proxy to use a free port, e.g. 8090
-* Start the brower directly from ZAP
+* Start the browser directly from ZAP
 
 


### PR DESCRIPTION
Fix typo in `brower` -> `browser`