### PR TITLE
Custom menu

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,9 +81,14 @@ java -jar webgoat-server-8.1.0.jar [--server.port=8080] [--server.address=localh
 java -jar webwolf-8.1.0.jar [--server.port=9090] [--server.address=localhost]
 ```
 
-The latest version of WebGoat needs Java 11 or above. By default WebGoat and WebWolf start on port 8080 and 9090 with `--server.port` you can specify a different port. With `server.address` you
-can bind it to a different address (default localhost)
-
+The latest version of WebGoat needs Java 11 or above. By default WebGoat and WebWolf start on port 8080,9000 and 9090 with the environment variable WEBGOAT_PORT and WEBGOAT_HSQLPORT you can set different values.
+```Shell
+export WEBGOAT_PORT=18080
+export WEBGOAT_HSQLPORT=19001
+java -jar webgoat-server-8.1.0.jar [--server.port=8080] [--server.address=localhost]
+java -jar webwolf-8.1.0.jar [--server.port=9090] [--server.address=localhost]
+```
+Use set in stead of export on Windows cmd.
 
 
 ## 3. Run from the sources
@@ -123,3 +128,13 @@ To change IP address add the following variable to WebGoat/webgoat-container/src
 server.address=x.x.x.x
 ```
 
+## 4. Run with custom menu
+
+For specialist only. There is a way to set up WebGoat with a personalized menu. You can leave out some menu categories or individual lessons by setting environment variables.
+
+For instance running as a jar on a Linux/MacOS it will look like:
+```Shell
+export EXCLUDE_CATEGORIES="CLIENT_SIDE,GENERAL,CHALLENGES"
+export EXCLUDE_LESSONS="SqlInjectionAdvanced,SqlInjectionMitigations"
+java -jar webgoat-server/target/webgoat-server-v8.2.0-SNAPSHOT.jar
+```

--- a/README.MD
+++ b/README.MD
@@ -81,14 +81,15 @@ java -jar webgoat-server-8.1.0.jar [--server.port=8080] [--server.address=localh
 java -jar webwolf-8.1.0.jar [--server.port=9090] [--server.address=localhost]
 ```
 
-The latest version of WebGoat needs Java 11 or above. By default WebGoat and WebWolf start on port 8080,9000 and 9090 with the environment variable WEBGOAT_PORT and WEBGOAT_HSQLPORT you can set different values.
+The latest version of WebGoat needs Java 11 or above. By default WebGoat and WebWolf start on port 8080,9000 and 9090 with the environment variable WEBGOAT_PORT, WEBWOLF_PORT and WEBGOAT_HSQLPORT you can set different values.
 ```Shell
 export WEBGOAT_PORT=18080
 export WEBGOAT_HSQLPORT=19001
-java -jar webgoat-server-8.1.0.jar [--server.port=8080] [--server.address=localhost]
-java -jar webwolf-8.1.0.jar [--server.port=9090] [--server.address=localhost]
+export WEBWOLF_PORT=19090
+java -jar webgoat-server-8.1.0.jar
+java -jar webwolf-8.1.0.jar 
 ```
-Use set in stead of export on Windows cmd.
+Use set in stead of export on Windows cmd. 
 
 
 ## 3. Run from the sources
@@ -134,7 +135,11 @@ For specialist only. There is a way to set up WebGoat with a personalized menu. 
 
 For instance running as a jar on a Linux/MacOS it will look like:
 ```Shell
-export EXCLUDE_CATEGORIES="CLIENT_SIDE,GENERAL,CHALLENGES"
+export EXCLUDE_CATEGORIES="CLIENT_SIDE,GENERAL,CHALLENGE"
 export EXCLUDE_LESSONS="SqlInjectionAdvanced,SqlInjectionMitigations"
 java -jar webgoat-server/target/webgoat-server-v8.2.0-SNAPSHOT.jar
+```
+Or in a docker run it would (once this version is pushed into docker hub) look like:
+```Shell
+docker run -d -p 80:8888 -p 8080:8080 -p 9090:9090 -e TZ=Europe/Amsterdam -e EXCLUDE_CATEGORIES="CLIENT_SIDE,GENERAL,CHALLENGE" -e EXCLUDE_LESSONS="SqlInjectionAdvanced,SqlInjectionMitigations" webgoat/goatandwolf
 ```

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
@@ -98,7 +98,7 @@ public class LessonMenuService {
             for (Lesson lesson : lessons) {
             	if (excludeLessons.contains(lesson.getName())) {
             		continue;
-            	}System.err.println(lesson.getName());
+            	}
                 LessonMenuItem lessonItem = new LessonMenuItem();
                 lessonItem.setName(lesson.getTitle());
                 lessonItem.setLink(lesson.getLink());

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
@@ -40,6 +40,7 @@ import org.owasp.webgoat.session.WebSession;
 import org.owasp.webgoat.users.LessonTracker;
 import org.owasp.webgoat.users.UserTracker;
 import org.owasp.webgoat.users.UserTrackerRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -65,6 +66,12 @@ public class LessonMenuService {
     private final WebSession webSession;
     private UserTrackerRepository userTrackerRepository;
 
+    @Value("#{'${exclude.categories}'.split(',')}")
+    private List<String> excludeCategories;
+
+    @Value("#{'${exclude.lessons}'.split(',')}")
+    private List<String> excludeLessons;
+    
     /**
      * Returns the lesson menu which is used to build the left nav
      *
@@ -79,6 +86,9 @@ public class LessonMenuService {
         UserTracker userTracker = userTrackerRepository.findByUser(webSession.getUserName());
 
         for (Category category : categories) {
+        	if (excludeCategories.contains(category.name())) { 
+        		continue;
+        	}
             LessonMenuItem categoryItem = new LessonMenuItem();
             categoryItem.setName(category.getName());
             categoryItem.setType(LessonMenuItemType.CATEGORY);
@@ -86,6 +96,9 @@ public class LessonMenuService {
             List<Lesson> lessons = course.getLessons(category);
             lessons = lessons.stream().sorted(Comparator.comparing(l -> l.getTitle())).collect(Collectors.toList());
             for (Lesson lesson : lessons) {
+            	if (excludeLessons.contains(lesson.getName())) {
+            		continue;
+            	}System.err.println(lesson.getName());
                 LessonMenuItem lessonItem = new LessonMenuItem();
                 lessonItem.setName(lesson.getTitle());
                 lessonItem.setLink(lesson.getLink());

--- a/webgoat-container/src/main/resources/application-webgoat.properties
+++ b/webgoat-container/src/main/resources/application-webgoat.properties
@@ -50,3 +50,9 @@ spring.jackson.serialization.write-dates-as-timestamps=false
 
 #For static file refresh ... and faster dev :D
 spring.devtools.restart.additional-paths=webgoat-container/src/main/resources/static/js,webgoat-container/src/main/resources/static/css
+
+exclude.categories=${EXCLUDE_CATEGORIES:none,none,CLIENT_SIDE}
+#exclude based on the enum of the Category
+
+exclude.lessons=${EXCLUDE_CATEGORIES:none,none}
+#exclude based on the class name of a lesson e.g.: LessonTemplate

--- a/webgoat-container/src/main/resources/application-webgoat.properties
+++ b/webgoat-container/src/main/resources/application-webgoat.properties
@@ -51,7 +51,7 @@ spring.jackson.serialization.write-dates-as-timestamps=false
 #For static file refresh ... and faster dev :D
 spring.devtools.restart.additional-paths=webgoat-container/src/main/resources/static/js,webgoat-container/src/main/resources/static/css
 
-exclude.categories=${EXCLUDE_CATEGORIES:none,none,CLIENT_SIDE}
+exclude.categories=${EXCLUDE_CATEGORIES:none,none}
 #exclude based on the enum of the Category
 
 exclude.lessons=${EXCLUDE_LESSONS:none,none}

--- a/webgoat-container/src/main/resources/application-webgoat.properties
+++ b/webgoat-container/src/main/resources/application-webgoat.properties
@@ -54,5 +54,5 @@ spring.devtools.restart.additional-paths=webgoat-container/src/main/resources/st
 exclude.categories=${EXCLUDE_CATEGORIES:none,none,CLIENT_SIDE}
 #exclude based on the enum of the Category
 
-exclude.lessons=${EXCLUDE_CATEGORIES:none,none}
+exclude.lessons=${EXCLUDE_LESSONS:none,none}
 #exclude based on the class name of a lesson e.g.: LessonTemplate

--- a/webgoat-container/src/test/java/org/owasp/webgoat/service/LessonMenuServiceTest.java
+++ b/webgoat-container/src/test/java/org/owasp/webgoat/service/LessonMenuServiceTest.java
@@ -47,6 +47,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+import java.util.Arrays;
+
 @RunWith(MockitoJUnitRunner.class)
 public class LessonMenuServiceTest {
 
@@ -64,7 +66,7 @@ public class LessonMenuServiceTest {
 
     @Before
     public void setup() {
-        this.mockMvc = standaloneSetup(new LessonMenuService(course, webSession, userTrackerRepository)).build();
+        this.mockMvc = standaloneSetup(new LessonMenuService(course, webSession, userTrackerRepository, Arrays.asList("none"), Arrays.asList("none"))).build();
     }
 
     @Test


### PR DESCRIPTION
Here is a solution for customising the categories and lessons. See the updated Readme for instructions on starting with Java, and here is how you would do it in a docker container: 
docker run -d -p 80:8888 -p 8080:8080 -p 9090:9090 -e TZ=Europe/Amsterdam -e EXCLUDE_CATEGORIES="CLIENT_SIDE,GENERAL,CHALLENGE" -e EXCLUDE_LESSONS="SqlInjectionAdvanced,SqlInjectionMitigations" webgoat/goatandwolf:latest-test

It will look like:
<img width="251" alt="Schermafbeelding 2020-11-24 om 15 58 42" src="https://user-images.githubusercontent.com/7931455/100113750-f36aa700-2e70-11eb-8e5c-7aeee5e79210.png">

By default only the Client side challenges are no longer shown. They can be enabled if you provide a category with none e.g.
EXCLUDE_CATEGORIES=none