### PR TITLE
flattened pom plugin added for easy build of seperate modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ webgoat.log
 webgoat.properties
 webgoat.script
 TestClass.class
+**/*.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,22 @@
 
 <build>
 	<plugins>
+	<plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.2.5</version>
+        <configuration>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
This plugin is added in order to still be able to build individual modules. It comes along with the use of the ${revision}