### PR TITLE
Fix SQL Injection line comments issue.

### DIFF
--- a/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content6.adoc
+++ b/webgoat-lessons/sql-injection/src/main/resources/lessonPlans/en/SqlInjection_content6.adoc
@@ -5,7 +5,7 @@
 /* */ 	 are inline comments
 -- , # 	 are line comments
 
-Example: SELECT * FROM users WHERE name = 'admin' --AND pass = 'pass'
+Example: SELECT * FROM users WHERE name = 'admin' -- AND pass = 'pass'
 ----
 
 


### PR DESCRIPTION
Fix SQL Injection line comments issue.

Issue:

```
Example: SELECT * FROM users WHERE name = 'admin' --AND pass = 'pass'
```

Should be:

```
Example: SELECT * FROM users WHERE name = 'admin' -- AND pass = 'pass'
```