### PR TITLE
Fixes #321

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <organization>
         <name>OWASP</name>
-        <url>https://webgoat.github.io/</url>
+        <url>https://github.com/WebGoat/WebGoat/</url>
     </organization>
 
     <parent>

--- a/webgoat-container/src/main/java/org/owasp/webgoat/AjaxAuthenticationEntryPoint.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/AjaxAuthenticationEntryPoint.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/AsciiDoctorTemplateResolver.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/AsciiDoctorTemplateResolver.java
@@ -4,7 +4,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/HammerHead.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/HammerHead.java
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpServletResponse;
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/LessonTemplateResolver.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/LessonTemplateResolver.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/MvcConfiguration.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/MvcConfiguration.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/WebGoat.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/WebGoat.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/WebSecurityConfig.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/WebSecurityConfig.java
@@ -3,7 +3,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/controller/StartLesson.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/controller/StartLesson.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/controller/Welcome.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/controller/Welcome.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  *
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Assignment.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Assignment.java
@@ -11,7 +11,7 @@ import java.util.List;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Category.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Category.java
@@ -9,7 +9,7 @@ import lombok.Getter;
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Hint.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/Hint.java
@@ -4,7 +4,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * 
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * 
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/LessonMenuItem.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/LessonMenuItem.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/lessons/LessonMenuItemType.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/lessons/LessonMenuItemType.java
@@ -4,7 +4,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * 
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * 
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LabelDebugService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LabelDebugService.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LabelService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LabelService.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/LessonMenuService.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/ReportCardService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/ReportCardService.java
@@ -5,7 +5,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project
  * utility. For details, please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/webgoat-container/src/main/java/org/owasp/webgoat/service/RestartLessonService.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/service/RestartLessonService.java
@@ -2,7 +2,7 @@
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/Course.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/Course.java
@@ -15,7 +15,7 @@ import static java.util.stream.Collectors.toList;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/session/WebSession.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/session/WebSession.java
@@ -15,7 +15,7 @@ import java.sql.SQLException;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details, please see
  * http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
  * License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later

--- a/webgoat-container/src/main/java/org/owasp/webgoat/users/LessonTracker.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/users/LessonTracker.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/main/java/org/owasp/webgoat/users/UserTracker.java
+++ b/webgoat-container/src/main/java/org/owasp/webgoat/users/UserTracker.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/test/java/org/owasp/webgoat/service/LabelServiceTest.java
+++ b/webgoat-container/src/test/java/org/owasp/webgoat/service/LabelServiceTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/test/java/org/owasp/webgoat/service/LessonProgressServiceTest.java
+++ b/webgoat-container/src/test/java/org/owasp/webgoat/service/LessonProgressServiceTest.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/test/java/org/owasp/webgoat/session/CourseTest.java
+++ b/webgoat-container/src/test/java/org/owasp/webgoat/session/CourseTest.java
@@ -5,7 +5,7 @@ package org.owasp.webgoat.session;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-container/src/test/java/org/owasp/webgoat/session/LessonTrackerTest.java
+++ b/webgoat-container/src/test/java/org/owasp/webgoat/session/LessonTrackerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/challenges/challenge1/Assignment1.java
+++ b/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/challenges/challenge1/Assignment1.java
@@ -15,7 +15,7 @@ import static org.owasp.webgoat.challenges.SolutionConstants.PASSWORD;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/client-side-filtering/src/main/java/org/owasp/webgoat/client_side_filtering/ClientSideFiltering.java
+++ b/webgoat-lessons/client-side-filtering/src/main/java/org/owasp/webgoat/client_side_filtering/ClientSideFiltering.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/html-tampering/src/main/java/org/owasp/webgoat/html_tampering/HtmlTampering.java
+++ b/webgoat-lessons/html-tampering/src/main/java/org/owasp/webgoat/html_tampering/HtmlTampering.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/http-proxies/src/main/java/org/owasp/webgoat/http_proxies/HttpProxies.java
+++ b/webgoat-lessons/http-proxies/src/main/java/org/owasp/webgoat/http_proxies/HttpProxies.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/idor/src/main/java/org/owasp/webgoat/idor/IDOR.java
+++ b/webgoat-lessons/idor/src/main/java/org/owasp/webgoat/idor/IDOR.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/insecure-deserialization/src/main/java/org/owasp/webgoat/deserialization/InsecureDeserialization.java
+++ b/webgoat-lessons/insecure-deserialization/src/main/java/org/owasp/webgoat/deserialization/InsecureDeserialization.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/insecure-login/src/main/java/org/owasp/webgoat/insecure_login/InsecureLogin.java
+++ b/webgoat-lessons/insecure-login/src/main/java/org/owasp/webgoat/insecure_login/InsecureLogin.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/missing_ac/DisplayUser.java
+++ b/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/missing_ac/DisplayUser.java
@@ -11,7 +11,7 @@ import java.util.Base64;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/ssrf/src/main/java/org/owasp/webgoat/ssrf/SSRF.java
+++ b/webgoat-lessons/ssrf/src/main/java/org/owasp/webgoat/ssrf/SSRF.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/webgoat-introduction/src/main/java/org/owasp/webgoat/introduction/WebGoatIntroduction.java
+++ b/webgoat-lessons/webgoat-introduction/src/main/java/org/owasp/webgoat/introduction/WebGoatIntroduction.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the

--- a/webgoat-lessons/xxe/src/main/java/org/owasp/webgoat/xxe/BlindSendFileAssignment.java
+++ b/webgoat-lessons/xxe/src/main/java/org/owasp/webgoat/xxe/BlindSendFileAssignment.java
@@ -27,7 +27,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
  * This file is part of WebGoat, an Open Web Application Security Project utility. For details,
  * please see http://www.owasp.org/
  * <p>
- * Copyright (c) 2002 - 20014 Bruce Mayhew
+ * Copyright (c) 2002 - 2014 Bruce Mayhew
  * <p>
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation; either version 2 of the


### PR DESCRIPTION
Fixes #321 

- Copyright year was "20014", replaced to "2014"
- Fixed the old github.io URL which no longer exist

See https://github.com/WebGoat/WebGoat/issues/321

There are other issues in #321 which are not addressed in this pull request or no longer relevant:

- Copyright contains link to http://webgoat.github.io/ (the webgoat.github.io no longer presents in the copyright text)
- Not all source files contain a copyright (a new separate "issue" or "pull request" should be created, if there are still source files without a copyright)
- The location in the source file is not consistent (also, a new separate "issue" or "pull request" should be created, if it is still the case)
- Add a complete license file (COPYING) at the top level directory (also, should be addressed separately)
Authors tag contains reference to old webgoat repository, we should delete the link (also, should be addressed separately)

Please consider accepting this pull request and consider #321 closed.