### PR TITLE
Fix typo in hints

### DIFF
--- a/webgoat-lessons/jwt/src/main/resources/i18n/WebGoatLabels.properties
+++ b/webgoat-lessons/jwt/src/main/resources/i18n/WebGoatLabels.properties
@@ -18,7 +18,7 @@ jwt-secret-incorrect-user=The user is {0}, you need to change it to WebGoat
 
 jwt-refresh-hint1=Look at the access log you will find a token there
 jwt-refresh-hint2=The token from the access log is no longer valid, can you find a way to refresh it?
-jwt-refresh-hint3=The endpoint for refreshing a token is 'jwt/refresh/newToken'
+jwt-refresh-hint3=The endpoint for refreshing a token is 'JWT/refresh/newToken'
 jwt-refresh-hint4=Use the found access token in the Authorization: Bearer header and use your own refresh token
 jwt-refresh-not-tom=User is not Tom but {0}, please try again
 


### PR DESCRIPTION
The hints for JWT used `jwt` instead of `JWT` which makes it difficult to solve the lesson as the hint actually points someone in the wrong direction.

Resolves: #123

Thank you for submitting a pull request to the WebGoat!