### PR TITLE
Fix link and typo

### DIFF
--- a/webgoat-lessons/insecure-deserialization/src/main/resources/lessonPlans/en/InsecureDeserialization_SimpleExploit.adoc
+++ b/webgoat-lessons/insecure-deserialization/src/main/resources/lessonPlans/en/InsecureDeserialization_SimpleExploit.adoc
@@ -12,7 +12,7 @@ AcmeObject acme = (AcmeObject)ois.readObject();
 ----
 
 It is expecting an `AcmeObject` object, but it will execute `readObject()` before the casting ocurs.
-If an attacker finds the proper class implementing dangerous operations in `readObject()`, he could serialize that object and force the vulnerable application to performe those actions.
+If an attacker finds the proper class implementing dangerous operations in `readObject()`, he could serialize that object and force the vulnerable application to perform those actions.
 
 === Class included in ClassPath
 

--- a/webgoat-lessons/ssrf/src/main/resources/lessonPlans/en/SSRF_Intro.adoc
+++ b/webgoat-lessons/ssrf/src/main/resources/lessonPlans/en/SSRF_Intro.adoc
@@ -1,9 +1,8 @@
-
 == Concept
-In a Server-Side Request Forgery (SSRF) attack, the attacker can abuse functionality on the server to read or update internal resources. The attacker can supply or modify a URL which the code running on the server will read or submit data to. And, by carefully selecting the URLs, the attacker may be able to read server configuration such as AWS metadata, connect to internal services like HTTP enabled databases or perform post requests towards internal services which are not intended to be exposed.
+In a Server-Side Request Forgery (SSRF) attack, the attacker can abuse functionality on the server to read or update internal resources. The attacker can supply or modify a URL which the code running on the server will read or submit data to. Moreover, by carefully selecting the URLs, the attacker may read server configuration such as AWS metadata, connect to internal services like HTTP enabled databases, or perform post requests towards internal services that are not intended to be exposed.
 
 == Goals
-In the exercises on the next pages, you need to examine what the browser sends to the server and how you can adjust the request to get other things from the server.
+In the exercises on the following pages, you need to examine what the browser sends to the server and adjust the request to get other things from the server.
 
 == SSRF How-To
 * https://www.hackerone.com/blog-How-To-Server-Side-Request-Forgery-SSRF

--- a/webgoat-lessons/ssrf/src/main/resources/lessonPlans/en/SSRF_Prevent.adoc
+++ b/webgoat-lessons/ssrf/src/main/resources/lessonPlans/en/SSRF_Prevent.adoc
@@ -1,11 +1,11 @@
-
 == Prevent
 
 To prevent SSRF vulnerabilities in web applications, it is recommended to adhere to the following guidelines:
 
-* Use a whitelist of allowed domains, resources and protocols from where the web server can fetch resources.
+* Use a whitelist of allowed domains, resources, and protocols from where the webserver can fetch resources.
 * Any input accepted from the user should be validated and rejected if it does not match the positive specification expected.
-* If possible, do not accept user input in functions that control where the web server can fetch resources.
+* If possible, do not accept user input in functions that control where the webserver can fetch resources.
 
 == References
-* https://www.owasp.org/index.php/Server_Side_Request_Forgery
+* https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+

--- a/webgoat-lessons/ssrf/src/main/resources/lessonPlans/en/SSRF_Task2.adoc
+++ b/webgoat-lessons/ssrf/src/main/resources/lessonPlans/en/SSRF_Task2.adoc
@@ -1,2 +1,2 @@
-=== Change the request so the server gets information from http://ifconfig.pro
+=== Change the request, so the server gets information from http://ifconfig.pro
 Click the button and figure out what happened.


### PR DESCRIPTION
The link pointed to the old OWASP website. Also fixed some typos here and there

Resolves: #1136

Thank you for submitting a pull request to the WebGoat!