### PR TITLE
openshift support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ FROM eclipse-temurin:17_35-jdk-focal
 RUN apt-get update
 RUN useradd -ms /bin/bash webgoat
 RUN apt-get -y install apt-utils nginx
+RUN chgrp -R 0 /home/webgoat
+RUN chmod -R g=u /home/webgoat
 
 USER webgoat
 


### PR DESCRIPTION
With the refactoring of the Dockerfile, the two lines required for anonymous rootless user conditions also disappeared. 
With the two statements back in place, webgoat/webwolf can also run on Openshift.  (The current webgoat/goatandwolf:latest does not work, the webgoat/goatandwolf:openshift made from this branch does work)