### PR TITLE
Update InsecureDeserializationTask.java

### DIFF
--- a/webgoat-lessons/insecure-deserialization/src/main/java/org/owasp/webgoat/deserialization/InsecureDeserializationTask.java
+++ b/webgoat-lessons/insecure-deserialization/src/main/java/org/owasp/webgoat/deserialization/InsecureDeserializationTask.java
@@ -31,10 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InvalidClassException;
-import java.io.ObjectInputStream;
+import java.io.*;
 import java.util.Base64;
 
 @RestController
@@ -43,13 +40,16 @@ public class InsecureDeserializationTask extends AssignmentEndpoint {
 
     @PostMapping("/InsecureDeserialization/task")
     @ResponseBody
-    public AttackResult completed(@RequestParam String token) throws IOException {
+    public AttackResult completed(@RequestParam ObjectStreamClass token) throws IOException {
         String b64token;
         long before;
         long after;
         int delay;
+        if(!token.getName().equals(VulnerableTaskHolder.class.getName())){
+            throw new InvalidClassException("Unauthorized deserialization", token.getName());
+        }
 
-        b64token = token.replace('-', '+').replace('_', '/');
+        b64token = token.getName().replace('-', '+').replace('_', '/');
 
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(b64token)))) {
             before = System.currentTimeMillis();


### PR DESCRIPTION
Se ha elegido una **vulnerabilidad** de tipo **Blocker** concretamente **NOT DESERIALIZE user-controlled data**. Esta vulnerabilidad consiste en la no comprobación de las entradas del usuario (como puede ser el caso de un post) antes de pasar a hacer la deserialización de los datos, el hecho de que no se comprueben dichos datos permite **dos tipos de ataque**. 

**RCE** (ejecución remota de código) modifica la estructura del contenido a serializar para cambiar el comportamiento del dato que se deserializa. Estas modificaciones se pueden traducir a su vez en **escalada de privilegios** o en producir cambios importantes en los datos de la aplicación. 
Por tanto, no se trata de un falso positivo ya que si se analiza el código de forma propia se puede observar que efectivamente no se realiza ninguna comprobación de los datos antes de pasar a la deserialización, por lo que es vulnerable a un ataque de inyección.
Como solución, hemos modificado el código para que se realice una comprobación de los datos antes de su deserialización. Lo primero que hacemos es comprobar y verificar la clase a la que pertenece que debe coincidir con la que nosotros esperamos. 

**Detección de la vulnerabilidad de tipo blocker con Sonar:**

![VULNERABILIDAD NOT DESERIALIZE user-controlled data](https://user-images.githubusercontent.com/91549054/162163297-a11b6314-dc5e-489c-af8a-a4e94ccd8948.png)

**Información sobre la vulnerabilidad ofrecida por Sonar (ataques RCE y escalado de privilegios):**

![VULNERABILIDAD NOT DESERIALIZE user-controlled data png 1](https://user-images.githubusercontent.com/91549054/162163397-267ae155-42de-4502-bd7a-9776b96a86bb.png)

**Código original vulnerable:**

![VULNERABILIDAD NOT DESERIALIZE user-controlled data png 2](https://user-images.githubusercontent.com/91549054/162163436-8b99fe39-8290-431c-bf0a-2832898e9bee.png)

**Solución vulnerabilidad añadiendo comprobación:**

![VULNERABILIDAD NOT DESERIALIZE user-controlled data png 3](https://user-images.githubusercontent.com/91549054/162163493-0f11747a-e32b-438d-961a-4239b0ab96e1.png)

