### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -5,6 +5,9 @@ on:
       - main
       - develop
       - release/*
+permissions:
+  contents: read
+
 jobs:
   install-notest:
     if: "github.repository != 'WebGoat/WebGoat'"

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -20,6 +20,9 @@ on:
       - 'LICENSE'
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
       - name: "Image digest"
         run: echo ${{ steps.docker_build.outputs.digest }}
   new_version:
+    permissions:
+      contents: write  # for Git to git push
     if: github.repository == 'WebGoat/WebGoat'
     name: Update development version
     needs: [ release ]


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
