### PR TITLE
i18n fix and improvement for login and register page

### DIFF
--- a/src/it/java/org/owasp/webgoat/LabelAndHintIntegrationTest.java
+++ b/src/it/java/org/owasp/webgoat/LabelAndHintIntegrationTest.java
@@ -90,13 +90,13 @@ public class LabelAndHintIntegrationTest extends IntegrationTest {
                 System.err.println("key: " + key + " in (" +lang+") is missing from default properties");
                 Assertions.fail();
             }
-            /*if (!jsonPath.getString(ESCAPE_JSON_PATH_CHAR+key+ESCAPE_JSON_PATH_CHAR).equals(propsLang.get(key))) {
+            if (!jsonPath.getString(ESCAPE_JSON_PATH_CHAR+key+ESCAPE_JSON_PATH_CHAR).equals(propsLang.get(key))) {
                 System.out.println("key: " + key + " in (" +lang+") has incorrect translation in label service");
                 System.out.println("actual:"+jsonPath.getString(ESCAPE_JSON_PATH_CHAR+key+ESCAPE_JSON_PATH_CHAR));
                 System.out.println("expected: "+propsLang.getProperty(key));
                 System.out.println();
-                //Assertions.fail();
-            }*/
+                Assertions.fail();
+            }
         }
     }
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -51,7 +51,7 @@ show.hints=Show hints
 lesson.overview=Lesson overview
 reset.lesson=Reset lesson
 sign.in=Sign in
-register.new=Register new user
+register.new=or register yourself as a new user
 sign.up=Sign up
 register.title=Register 
 
@@ -63,3 +63,12 @@ password.size=Password should at least contain 6 characters
 password.diff=The passwords do not match.
 security.enabled=Security enabled, you can try the previous challenges and see the effect!
 security.disabled=Security enabled, you can try the previous challenges and see the effect!
+termsofuse=Terms of use
+register.condition.1=While running this program your machine will be extremely vulnerable to attack.\
+  You should disconnect from the Internet while using this program. WebGoat's default configuration binds to localhost to minimize the exposure. 
+register.condition.2=This program is for educational purposes only. If you attempt \
+these techniques without authorization, you are very likely to get caught. If \
+you are caught engaging in unauthorized hacking, most companies will fire you. \
+Claiming that you were doing security research will not work as that is the \
+first thing that all hackers claim.
+terms.agree=Agree with the terms and conditions

--- a/src/main/resources/i18n/messages_nl.properties
+++ b/src/main/resources/i18n/messages_nl.properties
@@ -22,13 +22,16 @@
 # projects.
 # <p>
 #
-lesson.completed=Gefeliciteerd, je hebt de les succesvol afgerond.
+lesson.completed=Gefeliciteerd, je hebt deze les succesvol afgerond.
+assignment.solved=Gefeliciteerd, je hebt deze opdracht succesvol afgerond.
+assignment.not.solved=Sorry de oplossing is niet correct, probeer het nog eens.
 RestartLesson=Herstart de les
 SolutionVideos=Video oplossingen
 ErrorGenerating=Fout opgetreden tijdens generatie
 InvalidData=Ongeldige invoer
 Go!=Ga snel aan de slag!
 password=Wachtwoord
+password.confirm=Herhaal wachtwoord
 username=Gebruikersnaam
 logged_out=Je bent succesvol uitgelogd.
 invalid_username_password=Ongeldige gebruikersnaam/wachtwoord combinatie
@@ -46,4 +49,14 @@ contact=Neem contact met ons op
 show.hints=Toon hints
 lesson.overview=Overzicht les
 reset.lesson=Herstart les
-sign.in=Log in
+sign.in=Inloggen
+terms.agree=Ik ga akkoord met de voorwaarden
+sign.up=Registreer
+register.title=Aanmelden als nieuwe gebruiker
+register.new=of aanmelden als nieuwe gebruiker
+termsofuse=Gebruiksvoorwaarden
+register.condition.1=Wanneer u WebGoat runt op uw computer, bent u kwetsbaar voor cyber aanvallen. \
+  Zorg dat u geen verbinding heeft met internet en dat toegang tot WebGoat alleen lokaal mogelijk is om het aanvalsoppervlak te verkleinen.
+register.condition.2=WebGoat is bedoeld als educatieve applicatie op het gebied van secure software development. \
+  Gebruik wat u leert om applicaties beter te maken en niet om zonder toestemming applicaties te schaden. \
+  In dat laatste geval loopt u risico op rechtsvervoling en ontslag. 

--- a/src/main/resources/lessons/vulnerable_components/i18n/WebGoatLabels.properties
+++ b/src/main/resources/lessons/vulnerable_components/i18n/WebGoatLabels.properties
@@ -1,6 +1,5 @@
 vulnerable-components.title=Vulnerable Components
 EnterYourName=Enter your Name
-Go!=Go!
 vulnerable.hint=Did you search for CVE-2013-728 and read https://x-stream.github.io/CVE-2013-7285.html
 vulnerable-components.close=The payload send could not be deserialized to a Contact class. Please try again.
 vulnerable-components.success=You successfully tried to exploit the CVE-2013-7285 vulnerability

--- a/src/main/resources/webgoat/templates/login.html
+++ b/src/main/resources/webgoat/templates/login.html
@@ -32,11 +32,11 @@
                 <div class="form-group">
                     <label for="exampleInputEmail1" th:text="#{username}">Username</label>
                     <input autofocus="dummy_for_thymeleaf_parser" type="text" class="form-control"
-                           id="exampleInputEmail1" placeholder="Username" name='username' />
+                           id="exampleInputEmail1" th:placeholder="#{username}" name='username' />
                 </div>
                 <div class="form-group">
                     <label for="exampleInputPassword1" th:text="#{password}">Password</label>
-                    <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password"
+                    <input type="password" class="form-control" id="exampleInputPassword1" th:placeholder="#{password}"
                            name='password' />
                 </div>
                 <button class="btn btn-primary btn-block" type="submit" th:text="#{sign.in}">Sign in</button>

--- a/src/main/resources/webgoat/templates/registration.html
+++ b/src/main/resources/webgoat/templates/registration.html
@@ -31,14 +31,14 @@
                         <div class="col-sm-4">
                             <input autofocus="dummy_for_thymeleaf_parser" type="text" class="form-control"
                                    th:field="*{username}"
-                                   id="username" placeholder="Username" name='username'/>
+                                   id="username" th:placeholder="#{username}" name='username'/>
                         </div>
                         <span th:if="${#fields.hasErrors('username')}" th:errors="*{username}">Username error</span>
                     </div>
                     <div class="form-group" th:classappend="${#fields.hasErrors('password')}? 'has-error'">
                         <label for="password" class="col-sm-2 control-label" th:text="#{password}">Password</label>
                         <div class="col-sm-4">
-                            <input type="password" class="form-control" id="password" placeholder="Password"
+                            <input type="password" class="form-control" id="password" th:placeholder="#{password}"
                                    name='password' th:value="*{password}"/>
                         </div>
                         <span th:if="${#fields.hasErrors('password')}" th:errors="*{password}">Password error</span>
@@ -47,7 +47,7 @@
                         <label for="matchingPassword" class="col-sm-2 control-label" th:text="#{password.confirm}">Confirm
                             password</label>
                         <div class="col-sm-4">
-                            <input type="password" class="form-control" id="matchingPassword" placeholder="Password"
+                            <input type="password" class="form-control" id="matchingPassword" th:placeholder="#{password}"
                                    name='matchingPassword' th:value="*{matchingPassword}"/>
                         </div>
                         <span th:if="${#fields.hasErrors('matchingPassword')}" th:errors="*{matchingPassword}">Password error</span>
@@ -55,22 +55,11 @@
                     </div>
 
                     <div class="form-group" th:classappend="${#fields.hasErrors('agree')}? 'has-error'">
-                        <label class="col-sm-2 control-label">Terms of use</label>
+                        <label class="col-sm-2 control-label" th:text="#{termsofuse}">Terms of use</label>
                         <div class="col-sm-6">
                             <div style="border: 1px solid #e5e5e5; height: 200px; overflow: auto; padding: 10px;">
-                                <p>
-                                    While running this program your machine will be extremely
-                                    vulnerable to attack. You should disconnect from the Internet while using
-                                    this program. WebGoat's default configuration binds to localhost to minimize
-                                    the exposure.
-                                </p>
-                                <p>
-                                    This program is for educational purposes only. If you attempt
-                                    these techniques without authorization, you are very likely to get caught. If
-                                    you are caught engaging in unauthorized hacking, most companies will fire you.
-                                    Claiming that you were doing security research will not work as that is the
-                                    first thing that all hackers claim.
-                                </p>
+                                <p th:text="#{register.condition.1}" >Condition1</p>
+                                <p th:text="#{register.condition.2}">Condition2</p>
                             </div>
                         </div>
                     </div>
@@ -79,8 +68,8 @@
                         <div class="col-sm-6 col-sm-offset-2">
                             <div class="checkbox">
                                 <label>
-                                    <input type="checkbox" name="agree" value="agree"/>Agree with the terms and
-                                    conditions
+                                    <input type="checkbox" name="agree" value="agree"/><p th:text="#{terms.agree}">Agree with the terms and
+                                    conditions</p>
                                 </label>
                             </div>
                         </div>


### PR DESCRIPTION
This fixes one duplicate label key issue (Go!) and makes the register and login page fully customisable. Only fully implemented for English and Dutch, but at least is shows that it can be done.
The LabelAndHintIntegration test now also fails if labels in a language other than English are defined and not provided in English.