### PR TITLE
Update interface name to exploit

### DIFF
--- a/src/main/resources/lessons/vulnerablecomponents/documentation/VulnerableComponents_content5a.adoc
+++ b/src/main/resources/lessons/vulnerablecomponents/documentation/VulnerableComponents_content5a.adoc
@@ -13,6 +13,6 @@ WebGoat uses an XML document to add contacts to a contacts database.
 </contact>  
 ----
 
-The java interface that you need for the exercise is: org.owasp.webgoat.vulnerablecomponents.Contact.
+The java interface that you need for the exercise is: org.owasp.webgoat.lessons.vulnerablecomponents.Contact.
 Start by sending the above contact to see what the normal response would be and then read the CVE vulnerability  documentation (search the Internet) and try to trigger the vulnerability.
 For this example, we will let you enter the XML directly versus intercepting the request and modifying the data.  You provide the XML representation of a contact and WebGoat will convert it a Contact object using `XStream.fromXML(xml)`.


### PR DESCRIPTION
The name is
org.owasp.webgoat.lessons.vulnerablecomponents.Contact not
org.owasp.webgoat.vulnerablecomponents.Contact
