### PR TITLE
Add SSRF Regex restrictions

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask1.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask1.java
@@ -44,12 +44,12 @@ public class SSRFTask1 extends AssignmentEndpoint {
     try {
       StringBuilder html = new StringBuilder();
 
-      if (url.matches("images/tom.png")) {
+      if (url.matches("images/tom\\.png")) {
         html.append(
             "<img class=\"image\" alt=\"Tom\" src=\"images/tom.png\" width=\"25%\""
                 + " height=\"25%\">");
         return failed(this).feedback("ssrf.tom").output(html.toString()).build();
-      } else if (url.matches("images/jerry.png")) {
+      } else if (url.matches("images/jerry\\.png")) {
         html.append(
             "<img class=\"image\" alt=\"Jerry\" src=\"images/jerry.png\" width=\"25%\""
                 + " height=\"25%\">");

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -46,7 +46,7 @@ public class SSRFTask2 extends AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig.pro")) {
+    if (url.matches("http://ifconfig\\.pro")) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =


### PR DESCRIPTION
Hello!

While reading WebGoat's code, I saw that `String.matches()` is used while forgetting that it accepts a regex. 

For SSRF Task 1, this is not really an issue by looking at the code, but for SSRF Task 2, an actual SSRF could be done, albeit to a domain that matches the regex, and with extra DNS magic steps on the target/target infrastructure.

I used `ipconfig/pro` as an example, and as you can imagine, we can also think about `ipconfiggpro` or others.

My suggestion is to escape the dot.

Here are illustrative examples:

```java  
System.out.println((new String("images/jerry/png")).matches("images/jerry.png"));
// true

System.out.println((new String("images/jerry/png")).matches("images/jerry\\.png"));
// false
  
System.out.println((new String("http://ifconfig/pro")).matches("http://ifconfig.pro"));
// true

System.out.println((new String("http://ifconfig/pro")).matches("http://ifconfig\\.pro"));
// false
```

Cheers!