### PR TITLE
doc: fix version strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ docker run -p 127.0.0.1:3000:3000 webgoat/webgoat-desktop
 Download the latest WebGoat release from [https://github.com/WebGoat/WebGoat/releases](https://github.com/WebGoat/WebGoat/releases)
 
 ```shell
-java -Dfile.encoding=UTF-8 -Dwebgoat.port=8080 -Dwebwolf.port=9090 -jar webgoat-2023.3.jar
+java -Dfile.encoding=UTF-8 -Dwebgoat.port=8080 -Dwebwolf.port=9090 -jar webgoat-2023.4.jar
 ```
 
 Click the link in the log to start WebGoat.
@@ -134,7 +134,7 @@ For instance running as a jar on a Linux/macOS it will look like this:
 ```Shell
 export EXCLUDE_CATEGORIES="CLIENT_SIDE,GENERAL,CHALLENGE"
 export EXCLUDE_LESSONS="SqlInjectionAdvanced,SqlInjectionMitigations"
-java -jar target/webgoat-2023.3-SNAPSHOT.jar
+java -jar target/webgoat-2023.4-SNAPSHOT.jar
 ```
 
 Or in a docker run it would (once this version is pushed into docker hub) look like this:


### PR DESCRIPTION
Hi, I noticed that commands in README.md are from the previous version. And I decided to fix this minor issue. 
Thanks!
