### PR TITLE
WebWolf: Make webjar dependencies version agnostic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
     <thymeleaf.version>3.1.1.RELEASE</thymeleaf.version>
     <webdriver.version>5.3.2</webdriver.version>
     <webgoat.port>8080</webgoat.port>
+    <webjars-locator-core.version>0.53</webjars-locator-core.version>
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>2.27.2</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
@@ -240,6 +241,11 @@
         <groupId>org.webjars</groupId>
         <artifactId>jquery</artifactId>
         <version>${jquery.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars</groupId>
+        <artifactId>webjars-locator-core</artifactId>
+        <version>${webjars-locator-core.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
@@ -393,6 +399,10 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>jquery</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>webjars-locator-core</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/src/main/resources/webwolf/templates/fragments/header.html
+++ b/src/main/resources/webwolf/templates/fragments/header.html
@@ -3,10 +3,10 @@
     <title>WebWolf</title>
     <div th:fragment="header-css">
         <link rel="icon" th:href="@{/css/img/webwolf.ico}"/>
-        <link rel="stylesheet" type="text/css" th:href="@{/webjars/bootstrap/3.3.7/css/bootstrap.min.css}"/>
+        <link rel="stylesheet" type="text/css" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}"/>
         <link rel="stylesheet" th:href="@{/css/webwolf.css}"/>
-        <script th:src="@{/webjars/jquery/3.6.4/jquery.min.js}"></script>
-        <script th:src="@{/webjars/bootstrap/3.3.7/js/bootstrap.min.js}"></script>
+        <script th:src="@{/webjars/jquery/jquery.min.js}"></script>
+        <script th:src="@{/webjars/bootstrap/js/bootstrap.min.js}"></script>
     </div>
 </head>
 <body>


### PR DESCRIPTION
Update to make dependencies utilize the locator, ensuring WebJar is version-agnostic.

Solves #1567 