### PR TITLE
fix(sec): upgrade org.webjars:bootstrap to 4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <!-- Shared properties with plugins and version numbers across submodules-->
     <asciidoctorj.version>2.5.10</asciidoctorj.version>
     <!-- Upgrading needs UI work in WebWolf -->
-    <bootstrap.version>3.3.7</bootstrap.version>
+    <bootstrap.version>4.3.1</bootstrap.version>
     <cglib.version>3.3.0</cglib.version>
     <!-- do not update necessary for lesson -->
     <checkstyle.version>3.3.0</checkstyle.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.webjars:bootstrap 3.3.7
- [CVE-2018-14040](https://www.oscs1024.com/hd/CVE-2018-14040)


### What did I do？
Upgrade org.webjars:bootstrap from 3.3.7 to 4.3.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS