### PR TITLE
fix: servers id

### DIFF
--- a/src/main/resources/lessons/sqlinjection/db/migration/V2019_09_26_1__servers.sql
+++ b/src/main/resources/lessons/sqlinjection/db/migration/V2019_09_26_1__servers.sql
@@ -10,4 +10,4 @@ INSERT INTO SERVERS VALUES ('1', 'webgoat-dev', '192.168.4.0', 'AA:BB:11:22:CC:D
 INSERT INTO SERVERS VALUES ('2', 'webgoat-tst', '192.168.2.1', 'EE:FF:33:44:AB:CD', 'online', 'Test server');
 INSERT INTO SERVERS VALUES ('3', 'webgoat-acc', '192.168.3.3', 'EF:12:FE:34:AA:CC', 'offline', 'Acceptance server');
 INSERT INTO SERVERS VALUES ('4', 'webgoat-pre-prod', '192.168.6.4', 'EF:12:FE:34:AA:CC', 'offline', 'Pre-production server');
-INSERT INTO SERVERS VALUES ('4', 'webgoat-prd', '104.130.219.202', 'FA:91:EB:82:DC:73', 'out of order', 'Production server');
+INSERT INTO SERVERS VALUES ('5', 'webgoat-prd', '104.130.219.202', 'FA:91:EB:82:DC:73', 'out of order', 'Production server');


### PR DESCRIPTION
Hello, 

With my students as exercise, we also retrieved with a blind sql injection the `id` of the `webgoat-prd` and we were surprised to discover that the id was the same as the id of the `webgoat-pre-prod`.

To be realistic, the `id` of `webgoat-prd` should be `5` for example.

