### PR TITLE
Java 21 initial support

### DIFF
--- a/.github/workflows/branchbuild.yml
+++ b/.github/workflows/branchbuild.yml
@@ -1,30 +1,24 @@
-name: "Pull requests build"
+name: "Branch build"
 on:
-    pull_request:
-        paths-ignore:
-            - '.txt'
-            - 'LICENSE'
-            - 'docs/**'
+    push:
+      branches:
+        - "*"
+        - "!main"
 
 jobs:
-    pr-build:
-        if: >
-            github.event_name == 'pull_request' && !github.event.pull_request.draft && (
-              github.event.action == 'opened' ||
-              github.event.action == 'reopened' ||
-              github.event.action == 'synchronize' 
-            )
+    branch-build:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
+                java-version: [ 17, 21 ]
         steps:
             -   uses: actions/checkout@v3
-            -   name: Set up JDK 17
+            -   name: Set up JDK ${{ matrix.java-version }}
                 uses: actions/setup-java@v3
                 with:
                     distribution: 'temurin'
-                    java-version: 17
+                    java-version: ${{ matrix.java-version }}
                     architecture: x64
             -   name: Cache Maven packages
                 uses: actions/cache@v3.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
             - '.txt'
             - 'LICENSE'
             - 'docs/**'
+    push:
+      branches:
+        - "!main"
 
 jobs:
     pr-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
             - 'docs/**'
     push:
       branches:
+        - "*"
         - "!main"
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,14 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
+                java-version: [ 17, 21 ]
         steps:
             -   uses: actions/checkout@v3
-            -   name: Set up JDK 17
+            -   name: Set up JDK ${{ matrix.java-version }}
                 uses: actions/setup-java@v3
                 with:
                     distribution: 'temurin'
-                    java-version: 17
+                    java-version: ${{ matrix.java-version }}
                     architecture: x64
             -   name: Cache Maven packages
                 uses: actions/cache@v3.3.1

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.5</version>
   </parent>
 
   <groupId>org.owasp.webgoat</groupId>


### PR DESCRIPTION
First change to allow local compilation and test with JDK21
Build and release should still remain on Java17 for now
A branch build workflow is added to test code changes when still in a local or remote branch
