### PR TITLE
fix: typo in WebGoad.txt

### DIFF
--- a/config/desktop/WebGoat.txt
+++ b/config/desktop/WebGoat.txt
@@ -3,7 +3,7 @@
 With this image you have WebGoat and ZAP and a browser available to you in a browser running on Ubuntu.
 You can start WebGoat and ZAP by opening a terminal and type:
 
-./start-webgoat.sh
+./start_webgoat.sh
 ./start_zap.sh
 
 Happy hacking,


### PR DESCRIPTION
You can see that the file goes with the underscore 
https://github.com/WebGoat/WebGoat/blob/88a321c268e88dee06d19ed6a276d1012257853c/config/desktop/start_webgoat.sh