### PR TITLE
fix: typos in texts

### DIFF
--- a/src/main/resources/lessons/bypassrestrictions/documentation/BypassRestrictions_FieldRestrictions.adoc
+++ b/src/main/resources/lessons/bypassrestrictions/documentation/BypassRestrictions_FieldRestrictions.adoc
@@ -3,4 +3,4 @@ In most browsers, the client has complete or almost complete control over the HT
 of the webpage. They can alter values or restrictions to fit their preference.
 
 === Task
-Send a request that bypasses restrictions of all four of these fields.
+Send a request that bypasses restrictions of all five of these fields.

--- a/src/main/resources/lessons/xss/documentation/CrossSiteScripting_content4.adoc
+++ b/src/main/resources/lessons/xss/documentation/CrossSiteScripting_content4.adoc
@@ -12,5 +12,5 @@
 * Runs with browser privileges inherited from the user in a browser
 
 === Stored or persistent
-* Malicious content is stored on the server ( in a database, file system, or other objects) and later displayed to users in a web browser
+* Malicious content is stored on the server (in a database, file system, or other objects) and later displayed to users in a web browser
 * Social engineering is not required


### PR DESCRIPTION
There are actually five fields in this exercise (and attempting the exercise using only 4 of the fields will not validate it).

![fields](https://github.com/WebGoat/WebGoat/assets/752832/d7d9e242-a115-4958-8653-9b0cb40d1015)

Regards