### PR TITLE
fix: texts to avoid confusion

### DIFF
--- a/src/main/resources/lessons/httpbasics/documentation/HttpBasics_content2.adoc
+++ b/src/main/resources/lessons/httpbasics/documentation/HttpBasics_content2.adoc
@@ -1,3 +1,3 @@
 == The Quiz
 
-What type of HTTP command did WebGoat use for this lesson.  A POST or a GET.
+What type of HTTP verb does WebGoat use when submitting the form in this lesson?  A POST or a GET?

--- a/src/main/resources/lessons/httpbasics/html/HttpBasics.html
+++ b/src/main/resources/lessons/httpbasics/html/HttpBasics.html
@@ -64,7 +64,7 @@
 					<input type="hidden" name="magic_num" id="magic_num" value="foo" />
 					<table>
 						<tr>
-							<td>Was the HTTP command a POST or a GET:</td>
+							<td>Is this form sending a POST or a GET:</td>
 							<td><input name="answer" value="" type="TEXT" /></td>
 							<td></td>
 						</tr>


### PR DESCRIPTION
In this exercise, there is a confusion: because the sentences use a past tense, users tend to search for the answers in the HTTP requests of the previous exercise. But the way to solve this exercise is to post the form once, look at the HTTP verb and posted body and then answer and submit again.

IMHO, the it is much clearer now...