### PR TITLE
Fix hidden links in MissingFunctionAC.html.

### DIFF
--- a/src/main/resources/lessons/missingac/html/MissingFunctionAC.html
+++ b/src/main/resources/lessons/missingac/html/MissingFunctionAC.html
@@ -37,9 +37,8 @@
                         <li class="hidden-menu-item dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Admin<span class="caret"></span></a>
                             <ul class="dropdown-menu" aria-labelledby="admin">
-                                <li><a href="/access-control/users">Users</a></li>
-                                <li><a href="/access-control/users-admin-fix">Users</a></li>
-                                <li><a href="/access-control/config">Config</a></li>
+                                <li><a href="access-control/users-admin-fix">Users</a></li>
+                                <li><a href="access-control/config">Config</a></li>
                             </ul>
                         </li>
                     </ul>


### PR DESCRIPTION
This fixes 2 issues:
1. there are 3 links but the exercise expects 2 answers so it is confusing for users
2. the links href start with "/" so they are broken if Webgoat is deployed to a subfolder (e.g. `mysite.com/webgoat`)

Thanks!