### PR TITLE
fix: typo in SQLi blind case

### DIFF
--- a/src/main/resources/lessons/sqlinjection/documentation/SqlInjection_content13.adoc
+++ b/src/main/resources/lessons/sqlinjection/documentation/SqlInjection_content13.adoc
@@ -34,7 +34,7 @@ This means an `orderExpression` can be a `selectExpression` which can be a funct
 a `case` statement we might be able to ask the database some questions, like:
 
 ----
-SELECT * FROM users ORDER BY (CASE WHEN (TRUE) THEN lastname ELSE firstname)
+SELECT * FROM users ORDER BY (CASE WHEN (TRUE) THEN lastname ELSE firstname END)
 ----
 
 So we can substitute any kind of boolean operation in the `when(....)` part. The statement will just work because


### PR DESCRIPTION
Hi, in SQL `CASE` must end with `END` keyword.

* [case specification](https://hsqldb.org/doc/2.0/guide/dataaccess-chapt.html#N1300F)
```
CASE
case specification
<case specification> ::= <simple case> | <searched case>
<simple case> ::= CASE <case operand> <simple when clause>... [ <else clause> ] END
<searched case> ::= CASE <searched when clause>... [ <else clause> ] END 
```

