### PR TITLE
fix:  Success only if Smith earn most salary

### DIFF
--- a/src/main/resources/lessons/sqlinjection/i18n/WebGoatLabels.properties
+++ b/src/main/resources/lessons/sqlinjection/i18n/WebGoatLabels.properties
@@ -3,7 +3,7 @@
 2.sql.advanced.title=SQL Injection (advanced)
 3.sql.mitigation.title=SQL Injection (mitigation)
 
-
+        
 SqlInjectionChallenge1=Look at the different response you receive from the server
 SqlInjectionChallenge2=The vulnerability is on the register form
 SqlInjectionChallenge3=Use tooling to automate this attack
@@ -63,8 +63,8 @@ SqlStringInjectionHint.8.3=Try appending a SQL statement that always resolves to
 SqlStringInjectionHint.8.4=Make sure all quotes (" ' ") are opened and closed properly so the resulting SQL query is syntactically correct.
 SqlStringInjectionHint.8.5=Try extending the WHERE clause of the statement by adding something like: ' OR '1' = '1.
 
-sql-injection.9.success=Well done! Now you are earning the most money. And at the same time you successfully compromised the integrity of data by changing the salary!
-sql-injection.9.one=Still not earning enough! Better try again and change that.
+sql-injection.9.success=Well done! Now you are earning the most money. And at the same time you successfully compromised the integrity of data by changing your salary!
+sql-injection.9.one=Still not earning enough or only your own salary must be changed! Better try again and change that.
 SqlStringInjectionHint.9.1=Try to find a way, to chain another query to the end of the existing one.
 SqlStringInjectionHint.9.2=Use the ; metacharacter to do so.
 SqlStringInjectionHint.9.3=Make use of DML to change your salary.

--- a/src/test/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson9Test.java
+++ b/src/test/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson9Test.java
@@ -37,162 +37,88 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  */
 public class SqlInjectionLesson9Test extends SqlLessonTest {
 
-  private String completedError = "JSON path \"lessonCompleted\"";
+    private String completedError = "JSON path \"lessonCompleted\"";
 
-  @Test
-  public void oneAccount() throws Exception {
-    try {
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smith")
-                  .param("auth_tan", "3SL99A"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(false)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.one"))))
-          .andExpect(jsonPath("$.output", containsString("<table><tr><th>")));
-    } catch (AssertionError e) {
-      if (!e.getMessage().contains(completedError)) throw e;
+    @Test
+    public void malformedQueryReturnsError() throws Exception {
+        try {
+            mockMvc
+                    .perform(
+                            MockMvcRequestBuilders.post("/SqlInjection/attack9")
+                                    .param("name", "Smith")
+                                    .param("auth_tan", "3SL99A' OR '1' = '1'"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("lessonCompleted", is(false)))
+                    .andExpect(jsonPath("$.output", containsString("feedback-negative")));
+        } catch (AssertionError e) {
+            if (!e.getMessage().contains(completedError)) throw e;
 
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smith")
-                  .param("auth_tan", "3SL99A"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(true)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.success"))))
-          .andExpect(jsonPath("$.output", containsString("<table><tr><th>")));
+            mockMvc
+                    .perform(
+                            MockMvcRequestBuilders.post("/SqlInjection/attack9")
+                                    .param("name", "Smith")
+                                    .param("auth_tan", "3SL99A' OR '1' = '1'"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("lessonCompleted", is(true)))
+                    .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.success"))))
+                    .andExpect(jsonPath("$.output", containsString("feedback-negative")));
+        }
     }
-  }
 
-  @Test
-  public void multipleAccounts() throws Exception {
-    try {
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smith")
-                  .param("auth_tan", "3SL99A' OR '1' = '1"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(false)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.one"))))
-          .andExpect(
-              jsonPath(
-                  "$.output",
-                  containsString(
-                      "<tr><td>96134<\\/td><td>Bob<\\/td><td>Franco<\\/td><td>Marketing<\\/td><td>83700<\\/td><td>LO9S2V<\\/td><\\/tr>")));
-    } catch (AssertionError e) {
-      if (!e.getMessage().contains(completedError)) throw e;
-
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smith")
-                  .param("auth_tan", "3SL99A' OR '1' = '1"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(true)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.success"))))
-          .andExpect(
-              jsonPath(
-                  "$.output",
-                  containsString(
-                      "<tr><td>96134<\\/td><td>Bob<\\/td><td>Franco<\\/td><td>Marketing<\\/td><td>83700<\\/td><td>LO9S2V<\\/td><\\/tr>")));
+    @Test
+    public void SmithIsNotMostEarning() throws Exception {
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders.post("/SqlInjection/attack9")
+                                .param("name", "Smith")
+                                .param(
+                                        "auth_tan",
+                                        "3SL99A'; UPDATE employees SET salary = 9999 WHERE last_name = 'Smith"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("lessonCompleted", is(false)))
+                .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.one"))));
     }
-  }
 
-  @Test
-  public void wrongNameReturnsNoAccounts() throws Exception {
-    try {
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smithh")
-                  .param("auth_tan", "3SL99A"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(false)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.8.no.results"))))
-          .andExpect(jsonPath("$.output").doesNotExist());
-    } catch (AssertionError e) {
-      if (!e.getMessage().contains(completedError)) throw e;
-
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smithh")
-                  .param("auth_tan", "3SL99A"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(true)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.8.no.success"))))
-          .andExpect(jsonPath("$.output").doesNotExist());
+    @Test
+    public void OnlySmithSalaryMustBeUpdated() throws Exception {
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders.post("/SqlInjection/attack9")
+                                .param("name", "Smith")
+                                .param(
+                                        "auth_tan",
+                                        "3SL99A'; UPDATE employees SET salary = 9999 -- "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("lessonCompleted", is(false)))
+                .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.one"))));
     }
-  }
 
-  @Test
-  public void wrongTANReturnsNoAccounts() throws Exception {
-    try {
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smithh")
-                  .param("auth_tan", ""))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(false)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.8.no.results"))))
-          .andExpect(jsonPath("$.output").doesNotExist());
-    } catch (AssertionError e) {
-      if (!e.getMessage().contains(completedError)) throw e;
-
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smithh")
-                  .param("auth_tan", ""))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(true)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.success"))))
-          .andExpect(jsonPath("$.output").doesNotExist());
+    @Test
+    public void OnlySmithMustMostEarning () throws Exception {
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders.post("/SqlInjection/attack9")
+                                .param("name", "'; UPDATE employees SET salary = 999999 -- ")
+                                .param(
+                                        "auth_tan",
+                                        ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("lessonCompleted", is(false)))
+                .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.one"))));
     }
-  }
 
-  @Test
-  public void malformedQueryReturnsError() throws Exception {
-    try {
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smith")
-                  .param("auth_tan", "3SL99A' OR '1' = '1'"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(false)))
-          .andExpect(jsonPath("$.output", containsString("feedback-negative")));
-    } catch (AssertionError e) {
-      if (!e.getMessage().contains(completedError)) throw e;
-
-      mockMvc
-          .perform(
-              MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                  .param("name", "Smith")
-                  .param("auth_tan", "3SL99A' OR '1' = '1'"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("lessonCompleted", is(true)))
-          .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.success"))))
-          .andExpect(jsonPath("$.output", containsString("feedback-negative")));
+    @Test
+    public void SmithIsMostEarningCompletesAssignment() throws Exception {
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders.post("/SqlInjection/attack9")
+                                .param("name", "Smith")
+                                .param(
+                                        "auth_tan",
+                                        "3SL99A'; UPDATE employees SET salary = '300000' WHERE last_name = 'Smith"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("lessonCompleted", is(true)))
+                .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.success"))))
+                .andExpect(jsonPath("$.output", containsString("300000")));
     }
-  }
-
-  @Test
-  public void SmithIsMostEarningCompletesAssignment() throws Exception {
-    mockMvc
-        .perform(
-            MockMvcRequestBuilders.post("/SqlInjection/attack9")
-                .param("name", "Smith")
-                .param(
-                    "auth_tan",
-                    "3SL99A'; UPDATE employees SET salary = '300000' WHERE last_name = 'Smith"))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("lessonCompleted", is(true)))
-        .andExpect(jsonPath("$.feedback", is(messages.getMessage("sql-injection.9.success"))))
-        .andExpect(jsonPath("$.output", containsString("300000")));
-  }
 }


### PR DESCRIPTION
Hello,

Some students succeed the `SQL (intro) > lesson 9` by updating all the salaries of employees!

With this update it's no more possible ; I also changed the behavor of the response :
* the data returned are always the data employees ordered by `salary desc` (confidentiality injection remain in the previous lesson)
* the injection is commited only in success case
   * employees data remain clear
   * solutions too for all students
 
and of course:
* this pull request will not pass the current `SqlInjectionLesson9Test` :stop_sign: 
* but the updated test class  `SqlInjectionLesson9Test`  yes :ok: 
```
./mvnw test -Dtest="org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson9Test"
...

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson9Test
...
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.535 s -- in org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson9Test
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```