### PR TITLE
build(Dockerfile): replace deprecated MAINTAINER tag with label of the same

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/eclipse-temurin:21.0.1_12-jre
 LABEL NAME = "WebGoat: A deliberately insecure Web Application"
-MAINTAINER "WebGoat team"
+LABEL maintainer = "WebGoat team"
 
 RUN \
   useradd -ms /bin/bash webgoat && \

--- a/Dockerfile_desktop
+++ b/Dockerfile_desktop
@@ -1,6 +1,6 @@
 FROM lscr.io/linuxserver/webtop:ubuntu-xfce
 LABEL NAME = "WebGoat: A deliberately insecure Web Application"
-MAINTAINER "WebGoat team"
+LABEL maintainer = "WebGoat team"
 
 WORKDIR /config
 


### PR DESCRIPTION
Current syntax now used to denote the "WebGoat team" as maintainer

Link: https://docs.docker.com/reference/dockerfile/#label

Thank you for submitting a pull request to the WebGoat!
