### PR TITLE
This commit addresses critical security vulnerabilities in two depend…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <webwolf.context>/</webwolf.context>
     <wiremock.version>2.27.2</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.16</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.8.0</zxcvbn.version>
   </properties>
@@ -323,11 +323,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-thymeleaf</artifactId>
-    </dependency>
-    <dependency>
+      <dependency>
+          <groupId>org.thymeleaf</groupId>
+          <artifactId>thymeleaf</artifactId>
+          <version>3.1.2.RELEASE</version>
+      </dependency>
+      <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>


### PR DESCRIPTION
…encies:

1. `com.thoughtworks.xstream:xstream` is updated from 1.4.5 to 1.4.16 to mitigate a vulnerability that allows deserialization of untrusted data. The flaw could enable a remote attacker to execute arbitrary code by manipulating the input stream processed by the application. This update closes a potential remote code execution (RCE) vector.

2. `org.thymeleaf:thymeleaf` is replaced with version 3.1.2.RELEASE instead of the bundled version in `org.springframework.boot:spring-boot-starter-thymeleaf@3.1.5`. This change addresses a sandbox bypass issue where insufficient checks in the affected versions could allow an attacker to execute arbitrary code via a specially crafted HTML input.

Thank you for submitting a pull request to the WebGoat!
