### PR TITLE
Update HttpBasics_plan.adoc - https://www.zaproxy.org/

### DIFF
--- a/src/main/resources/lessons/httpbasics/documentation/HttpBasics_plan.adoc
+++ b/src/main/resources/lessons/httpbasics/documentation/HttpBasics_plan.adoc
@@ -8,7 +8,7 @@ This lesson presents the basics for understanding the transfer of data between t
 
 The user should become familiar with the features of WebGoat by manipulating the above
 buttons to view hints, show the HTTP request parameters, the HTTP request cookies, and the Java source code. You may also try using
-link:https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project[OWASP Zed Attack Proxy] for the first time.
+link:https://www.zaproxy.org/[OWASP Zed Attack Proxy] for the first time.
 
 === How HTTP works:
 


### PR DESCRIPTION
docs: minor: fix broken link OWASP ZAP - use official website link https://www.zaproxy.org/ ([src](https://fr.wikipedia.org/wiki/OWASP_ZAP))

It seems that ZAP is not directly published under OWASP website now but has it's own domain.

broken link:  https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project

(sorry for the branch name I initiate this PR with github UI. I'll do better branch name next time).