### PR TITLE
"fix": reset form and quiz color on reset lesson

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson5a.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson5a.java
@@ -41,8 +41,8 @@ public class SqlInjectionLesson5a extends AssignmentEndpoint {
           + " '1'</span> always evaluates to true (The string ending literal for '1 is closed by"
           + " the query itself, so you should not inject it). So the injected query basically looks"
           + " like this: <span style=\"font-style: italic\">SELECT * FROM user_data WHERE"
-          + " first_name = 'John' and last_name = '' or TRUE</span>, which will always evaluate to"
-          + " true, no matter what came before it.";
+          + " (first_name = 'John' and last_name = '') or (TRUE)</span>, which will always evaluate"
+          + " to true, no matter what came before it.";
   private final LessonDataSource dataSource;
 
   public SqlInjectionLesson5a(LessonDataSource dataSource) {

--- a/src/main/resources/webgoat/static/js/goatApp/view/LessonContentView.js
+++ b/src/main/resources/webgoat/static/js/goatApp/view/LessonContentView.js
@@ -147,7 +147,6 @@ define(['jquery',
             },
 
             markAssignmentComplete: function () {
-                this.curForm.reset();
                 $(this.curForm).siblings('.assignment-success').find('i').removeClass('hidden');
                 this.paginationControlView.updateCollection();
             },
@@ -222,6 +221,8 @@ define(['jquery',
             },
 
             resetLesson: function () {
+                this.$el.find(form).trigger("reset");
+                this.$el.find(".quiz_question").removeClass('correct incorrect');
                 this.$el.find('.attack-feedback').hide();
                 this.$el.find('.attack-output').hide();
                 this.markAssignmentIncomplete();


### PR DESCRIPTION
1. exercice forms are not reset on success, so user can see why he successed
![you-succeeded-02](https://github.com/user-attachments/assets/d510eb4e-fa29-42eb-93ad-078dd9b2b968)
1. exercice forms are reset  when resetting lesson
1. quizzes colors are removed  when resetting lesson (fix)


