### PR TITLE
fix: remove implicit context path guessing

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/lessons/CourseConfiguration.java
+++ b/src/main/java/org/owasp/webgoat/container/lessons/CourseConfiguration.java
@@ -30,6 +30,7 @@ import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AssignmentHints;
 import org.owasp.webgoat.container.assignments.AttackResult;
 import org.owasp.webgoat.container.session.Course;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;
@@ -42,10 +43,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class CourseConfiguration {
   private final List<Lesson> lessons;
   private final List<AssignmentEndpoint> assignments;
+  private final String contextPath;
 
-  public CourseConfiguration(List<Lesson> lessons, List<AssignmentEndpoint> assignments) {
+  public CourseConfiguration(
+      List<Lesson> lessons,
+      List<AssignmentEndpoint> assignments,
+      @Value("${server.servlet.context-path}") String contextPath) {
     this.lessons = lessons;
     this.assignments = assignments;
+    this.contextPath = contextPath.equals("/") ? "" : contextPath;
   }
 
   private void attachToLessonInParentPackage(
@@ -124,7 +130,7 @@ public class CourseConfiguration {
       if (methodReturnTypeIsOfTypeAttackResult(m)) {
         var mapping = getMapping(m);
         if (mapping != null) {
-          return mapping;
+          return contextPath + mapping;
         }
       }
     }

--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson5b.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson5b.java
@@ -22,7 +22,6 @@
 
 package org.owasp.webgoat.lessons.sqlinjection.introduction;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.sql.*;
 import org.owasp.webgoat.container.LessonDataSource;
@@ -52,8 +51,7 @@ public class SqlInjectionLesson5b extends AssignmentEndpoint {
 
   @PostMapping("/SqlInjection/assignment5b")
   @ResponseBody
-  public AttackResult completed(
-      @RequestParam String userid, @RequestParam String login_count, HttpServletRequest request)
+  public AttackResult completed(@RequestParam String userid, @RequestParam String login_count)
       throws IOException {
     return injectableQuery(login_count, userid);
   }

--- a/src/main/resources/webgoat/static/js/goatApp/controller/LessonController.js
+++ b/src/main/resources/webgoat/static/js/goatApp/controller/LessonController.js
@@ -121,7 +121,6 @@ define(['jquery',
 
             this.showHintsView = function() {
                 var self=this;
-                console.log(self.name);
                 if (!this.lessonHintView) {
                     this.createLessonHintView();
                 }

--- a/src/main/resources/webgoat/static/js/goatApp/view/LessonContentView.js
+++ b/src/main/resources/webgoat/static/js/goatApp/view/LessonContentView.js
@@ -68,10 +68,6 @@ define(['jquery',
                 }
             },
 
-            getCurrentPage: function () {
-                return this.currentPage;
-            },
-
             makeFormsAjax: function () {
                 this.$form = $('form.attack-form');
                 // turn off standard submit

--- a/src/main/resources/webgoat/static/js/goatApp/view/PaginationControlView.js
+++ b/src/main/resources/webgoat/static/js/goatApp/view/PaginationControlView.js
@@ -47,7 +47,6 @@ define(['jquery',
                 var pages = [];
 
                 _.each(this.collection.models, function(model) {
-                    //alert (model.get('solved'));
                      if (model.get('solved')) {
                         var key = model.get('assignment').path.replace(/\//g,'');
                         solvedMap[key] = model.get('assignment').name;
@@ -57,7 +56,6 @@ define(['jquery',
 
                 isAttackSolved = function (path) {
                     //strip
-                    //var newPath = path.replace(/^\/WebGoat/,'');
                     var newPath = path.replace(/\//g,'');
                     if (typeof solvedMap[newPath] !== 'undefined') {
                         return true;


### PR DESCRIPTION
Pass the context-path in the assignment overview so the frontend can easily match an assignment.

Thank you for submitting a pull request to the WebGoat!
