### PR TITLE
fix: Hint labels showing default text regardless of localization

### DIFF
--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -48,6 +48,7 @@ report.card=Report card
 about=About WebGoat
 contact=Contact Us
 show.hints=Show hints
+hide.hints=Hide hints
 lesson.overview=Lesson overview
 reset.lesson=Reset lesson
 sign.in=Sign in

--- a/src/main/resources/webgoat/static/js/goatApp/view/HintView.js
+++ b/src/main/resources/webgoat/static/js/goatApp/view/HintView.js
@@ -32,9 +32,9 @@ function($,
 
         toggleLabel: function() {
             if (this.isVisible()) {
-                $('#show-hints-button').text('Hide hints');
-            } else {
-                $('#show-hints-button').text('Show hints');
+				$('#show-hints-button').text(polyglot.t("hide.hints"))
+			} else {
+				$('#show-hints-button').text(polyglot.t("show.hints"))
             }
         },
 


### PR DESCRIPTION
### Motivation:

Regardless of the presence of localized label for the hint button, when toggling the button, default hardcoded text would be displayed.

### Modification:

In the `toggleLabel` function in `HintView.js`, `polyglot` is used to translate the hint labels rather than using hardcoded texts.

### Result:

The hint button correctly shows the localized labels for the hint button and falling back to the English version if it is absent.

Fixes #1944