### PR TITLE
fix: challenge introduction page loads

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/LessonTemplateResolver.java
+++ b/src/main/java/org/owasp/webgoat/container/LessonTemplateResolver.java
@@ -47,17 +47,26 @@ public class LessonTemplateResolver extends FileTemplateResolver {
     var templateName = resourceName.substring(PREFIX.length());
     byte[] resource = resources.get(templateName);
     if (resource == null) {
-      try {
-        resource =
-            resourceLoader
-                .getResource("classpath:/" + templateName)
-                .getInputStream()
-                .readAllBytes();
-      } catch (IOException e) {
-        log.error("Unable to find lesson HTML: {}", template);
-      }
-      resources.put(templateName, resource);
+      resource = loadAndCache(templateName);
+    }
+
+    if (resource == null) {
+      return new StringTemplateResource("Unable to find lesson HTML: %s".formatted(templateName));
     }
     return new StringTemplateResource(new String(resource, StandardCharsets.UTF_8));
+  }
+
+  private byte[] loadAndCache(String templateName) {
+    try {
+      var resource =
+          resourceLoader.getResource("classpath:/" + templateName).getInputStream().readAllBytes();
+      resources.put(templateName, resource);
+      return resource;
+    } catch (IOException e) {
+      log.error(
+          "Unable to find lesson HTML: '{}', does the name of HTML file name match the lesson class name?",
+          templateName);
+      return null;
+    }
   }
 }

--- a/src/main/resources/lessons/challenges/html/Challenge1.html
+++ b/src/main/resources/lessons/challenges/html/Challenge1.html
@@ -3,9 +3,6 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <div class="lesson-page-wrapper">
-    <div class="adoc-content" th:replace="~{doc:lessons/challenges/documentation/Challenge_introduction.adoc}"></div>
-</div>
-<div class="lesson-page-wrapper">
     <div class="attack-container">
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
 

--- a/src/main/resources/lessons/challenges/html/ChallengeIntro.html
+++ b/src/main/resources/lessons/challenges/html/ChallengeIntro.html
@@ -1,4 +1,4 @@
-    <!DOCTYPE html>
+<!DOCTYPE html>
 
 <html xmlns:th="http://www.thymeleaf.org">
 


### PR DESCRIPTION
The name of the html now matches the name of the lesson class. This PR also removes the introduction text from challenge 1

Closes: gh-2069