### PR TITLE
Fix SQL injection vulnerability in JWTHeaderKIDEndpoint

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/jwt/claimmisuse/JWTHeaderKIDEndpoint.java
+++ b/src/main/java/org/owasp/webgoat/lessons/jwt/claimmisuse/JWTHeaderKIDEndpoint.java
@@ -69,11 +69,10 @@ public class JWTHeaderKIDEndpoint implements AssignmentEndpoint {
                       public byte[] resolveSigningKeyBytes(JwsHeader header, Claims claims) {
                         final String kid = (String) header.get("kid");
                         try (var connection = dataSource.getConnection()) {
-                          ResultSet rs =
-                              connection
-                                  .createStatement()
-                                  .executeQuery(
-                                      "SELECT key FROM jwt_keys WHERE id = '" + kid + "'");
+                          var preparedStatement = connection.prepareStatement(
+                              "SELECT key FROM jwt_keys WHERE id = ?");
+                          preparedStatement.setString(1, kid);
+                          ResultSet rs = preparedStatement.executeQuery();
                           while (rs.next()) {
                             return TextCodec.BASE64.decode(rs.getString(1));
                           }


### PR DESCRIPTION
## Summary
This PR fixes a SQL injection vulnerability in the JWT Header KID Endpoint.

## Issue
- The application's resolveSigningKeyBytes method executes an SQL query with user-controlled input from the JWT header 'kid' parameter
- The original implementation uses string concatenation, making it vulnerable to SQL injection attacks

## Fix
- Replaced string concatenation with prepared statements
- Used parameterized query with proper binding for 'kid' parameter
- Fixed vulnerability at line ~75 in JWTHeaderKIDEndpoint.java

## Testing
- Proper handling of special characters in 'kid' parameter
- Normal JWT processing functionality maintained
- SQL injection attacks prevented
