### PR TITLE
Fix: EXCLUDE_LESSONS not excluding lessons as expected

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/service/LessonMenuService.java
+++ b/src/main/java/org/owasp/webgoat/container/service/LessonMenuService.java
@@ -61,7 +61,7 @@ public class LessonMenuService {
       List<Lesson> lessons = course.getLessons(category);
       lessons = lessons.stream().sorted(Comparator.comparing(Lesson::getTitle)).toList();
       for (Lesson lesson : lessons) {
-        if (excludeLessons.contains(lesson.getName())) {
+        if (excludeLessons.contains(lesson.getName().toString())) {
           continue;
         }
         LessonMenuItem lessonItem = new LessonMenuItem();


### PR DESCRIPTION
This PR fixes an issue where lessons listed in the `EXCLUDE_LESSONS` environment variable were not being excluded. The exclusion logic has been corrected to properly filter out specified lessons.

Fixes #2114 