### PR TITLE
Fixed wrong Content-Type header usage in missingac lesson

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/missingac/MissingFunctionACUsers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/missingac/MissingFunctionACUsers.java
@@ -49,7 +49,7 @@ public class MissingFunctionACUsers {
 
   @GetMapping(
       path = {"access-control/users"},
-      consumes = "application/json")
+      produces = "application/json")
   @ResponseBody
   public ResponseEntity<List<DisplayUser>> usersService() {
     return ResponseEntity.ok(

--- a/src/main/resources/lessons/missingac/i18n/WebGoatLabels.properties
+++ b/src/main/resources/lessons/missingac/i18n/WebGoatLabels.properties
@@ -15,11 +15,11 @@ access-control.hash.hint1=This assignment involves one simple change in a GET re
 access-control.hash.hint2=If you haven't found the hidden menus from the earlier exercise, go do that first.
 access-control.hash.hint3=When you look at the users page, there is a hint that more info is viewable by a given role.
 access-control.hash.hint4=Have you tried tampering the GET request? Different content-types?
-access-control.hash.hint5=Modify the GET request to '/access-control/users' to include 'Content-Type': 'application/json'
+access-control.hash.hint5=Modify the GET request to '/access-control/users' to include 'Accept': 'application/json'
 
 access-control.hash.hint6=Now for the harder way ... it builds on the easier way
 access-control.hash.hint7=If the request to view users, were a 'service' or 'RESTful' endpoint, what would be different about it?
-access-control.hash.hint8=If you're still looking for hints ... try changing the Content-type header as in the GET request.
+access-control.hash.hint8=If you're still looking for hints ... try changing the Accept header as in the GET request.
 access-control.hash.hint9=Assuming the administrators have fixed the user management as a RESTful endpoint, what alternative approaches, apart from the type of request discussed in the previous lesson, could you explore?
 access-control.hash.hint10=To determine the correct payload for the request, it's essential to examine how the registration process operates. Ensure that the payload is properly formatted according to the content type you defined earlier. Additionally, consider what information the response reveals when you submit an empty payload using the previously identified content type.
 access-control.hash.hint11=You will want to add your own username with an admin role. Yes, you'd have to guess/fuzz this in a real-world setting.

--- a/src/test/java/org/owasp/webgoat/lessons/missingac/MissingFunctionACUsersTest.java
+++ b/src/test/java/org/owasp/webgoat/lessons/missingac/MissingFunctionACUsersTest.java
@@ -27,7 +27,7 @@ class MissingFunctionACUsersTest extends LessonTest {
     mockMvc
         .perform(
             MockMvcRequestBuilders.get("/access-control/users")
-                .header("Content-type", "application/json"))
+                .header("Accept", "application/json"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].username", CoreMatchers.is("Tom")))
         .andExpect(
@@ -52,7 +52,7 @@ class MissingFunctionACUsersTest extends LessonTest {
     mockMvc
         .perform(
             MockMvcRequestBuilders.get("/access-control/users")
-                .header("Content-type", "application/json"))
+                .header("Accept", "application/json"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.size()", is(4)));
   }


### PR DESCRIPTION
In RFC for specify content-type from server [Accept](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2) header is used, so it's better to replace replace incorrect behavior with Content-Type header in request.