### PR TITLE
:book: Clarify brute-force assumption in Secure Passwords cracking timeClarify secure password lesson

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/securepasswords/SecurePasswordsAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/securepasswords/SecurePasswordsAssignment.java
@@ -60,7 +60,7 @@ public class SecurePasswordsAssignment implements AssignmentEndpoint {
                 (long) strength.getCrackTimeSeconds().getOnlineNoThrottling10perSecond())
             + "</br>");
       output.append(
-              "<i>Note:</i> This estimate assumes a brute-force attack and does not account for "
+              "<i>Note:</i> This estimate assumes brute-force attack and does not account for "
                       + "dictionary or rule-based attacks, which can significantly reduce real-world cracking time "
                       + "for common phrases.</br>");
     if (strength.getFeedback().getWarning().length() != 0)


### PR DESCRIPTION
### What does this PR change?

It explains that the displayed cracking time assumes a brute-force
attack and does not account for dictionary or rule-based attacks, which can
significantly reduce real-world cracking time for common phrases.

### Why is this change needed?

Without this clarification, long but common passwords (for example, happybirthdaytoyou) may appear more secure than they actually are, which can be misleading
for learners.

### Scope of change

- Documentation / lesson explanation only  
- No changes to password scoring or cracking logic  

Fixes #2259
