### PR TITLE
Use null-safe string comparison to prevent NullPointerException in Sq…

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson2.java
@@ -49,10 +49,14 @@ public class SqlInjectionLesson2 implements AssignmentEndpoint {
       ResultSet results = statement.executeQuery(query);
       StringBuilder output = new StringBuilder();
 
-      results.first();
+      if(!results.first()) {
+          return failed(this).feedback("sql-injection.2.failed").build();
+      }
 
-      if (results.getString("department").equals("Marketing")) {
-        output.append("<span class='feedback-positive'>" + query + "</span>");
+      if ("Marketing".equals(results.getString("department"))) {
+        output.append("<span class='feedback-positive'>")
+                .append(query)
+                .append("</span>");
         output.append(SqlInjectionLesson8.generateTable(results));
         return success(this).feedback("sql-injection.2.success").output(output.toString()).build();
       } else {


### PR DESCRIPTION
SqlInjectionLesson2

Replaced direct string comparison with a null-safe comparison.

Changed:
results.getString("department").equals("Marketing")

to:
"Marketing".equals(results.getString("department"))

This prevents a potential NullPointerException and follows common Java best practices of

"constant".equals(variable)