### PR TITLE
fix: SQL injection, weak MD5, path traversal

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/cryptography/HashingAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/cryptography/HashingAssignment.java
@@ -36,7 +36,7 @@ public class HashingAssignment implements AssignmentEndpoint {
 
       String secret = SECRETS[new Random().nextInt(SECRETS.length)];
 
-      MessageDigest md = MessageDigest.getInstance("MD5");
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
       md.update(secret.getBytes());
       byte[] digest = md.digest();
       md5Hash = DatatypeConverter.printHexBinary(digest).toUpperCase();

--- a/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileUploadRetrieval.java
+++ b/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileUploadRetrieval.java
@@ -97,8 +97,15 @@ public class ProfileUploadRetrieval implements AssignmentEndpoint {
     }
     try {
       var id = request.getParameter("id");
-      var catPicture =
-          new File(catPicturesDirectory, (id == null ? RandomUtils.nextInt(1, 11) : id) + ".jpg");
+      var resolvedPath =
+          catPicturesDirectory
+              .toPath()
+              .resolve((id == null ? String.valueOf(RandomUtils.nextInt(1, 11)) : id) + ".jpg")
+              .normalize();
+      if (!resolvedPath.startsWith(catPicturesDirectory.toPath())) {
+        return ResponseEntity.badRequest().body("Invalid path");
+      }
+      var catPicture = resolvedPath.toFile();
 
       if (catPicture.getName().toLowerCase().contains("path-traversal-secret.jpg")) {
         return ResponseEntity.ok()

--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
@@ -51,10 +51,11 @@ public class SqlInjectionChallenge implements AssignmentEndpoint {
     if (attackResult == null) {
 
       try (Connection connection = dataSource.getConnection()) {
-        String checkUserQuery =
-            "select userid from sql_challenge_users where userid = '" + username + "'";
-        Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(checkUserQuery);
+        PreparedStatement checkStatement =
+            connection.prepareStatement(
+                "select userid from sql_challenge_users where userid = ?");
+        checkStatement.setString(1, username);
+        ResultSet resultSet = checkStatement.executeQuery();
 
         if (resultSet.next()) {
           attackResult = failed(this).feedback("user.exists").feedbackArgs(username).build();


### PR DESCRIPTION
Fixes found by Semgrep SAST scan.

- `SqlInjectionChallenge.java`: replace raw `Statement` with `PreparedStatement` (CWE-89)
- `HashingAssignment.java`: replace `MD5` with `SHA-256` (CWE-328)
- `ProfileUploadRetrieval.java`: add path normalization and boundary check (CWE-22)