### PR TITLE
Enhance WebWolf error page with additional diagnostic details

### DIFF
--- a/src/main/resources/webwolf/templates/error.html
+++ b/src/main/resources/webwolf/templates/error.html
@@ -7,33 +7,52 @@
 </head>
 <body>
 
-
 <div th:replace="~{fragments/header :: header}"/>
 
 <div class="container">
 
-		<h1>WebWolf</h1>
-		<p>This is the general error page of WebWolf. It applies for all 404, 500 etc messages.</p>
-		<p>Sometimes you will end up on this page on purpose because of a fake call to WebGoat which is redirected to WebWolf.
-		In that situation, you are probably interested in seeing the detail of the request. Login to WebWolf and check the incoming requests.</p>
+    <h1>WebWolf</h1>
+    <p>This is the general error page of WebWolf. It applies for all 404, 500 etc messages.</p>
+    <p>Sometimes you will end up on this page on purpose because of a fake call to WebGoat which is redirected to WebWolf.
+        In that situation, you are probably interested in seeing the detail of the request. Login to WebWolf and check the incoming requests.</p>
 
-		<br/>
+    <br/>
 
-		<table>
-    <tr>
-        <td>Date: </td>
-        <td th:text="${timestamp}"/>
-    </tr>
-    <tr>
-        <td>Path: </td>
-        <td th:text="${path}"/>
-    </tr>
-    <tr>
-        <td>Status: </td>
-        <td th:text="${status}"/>
-    </tr>
-</table>
-	</div>
+    <table>
+        <tr>
+            <td>Date: </td>
+            <td th:text="${timestamp}"/>
+        </tr>
+        <tr>
+            <td>Path: </td>
+            <td th:text="${path}"/>
+        </tr>
+        <tr>
+            <td>Status: </td>
+            <td th:text="${status}"/>
+        </tr>
+    </table>
+
+    <br/>
+
+    <h3>Additional Information</h3>
+
+    <table>
+        <tr>
+            <td>Error:</td>
+            <td th:text="${error}"></td>
+        </tr>
+        <tr>
+            <td>Message:</td>
+            <td th:text="${message}"></td>
+        </tr>
+        <tr>
+            <td>Request ID / Trace:</td>
+            <td th:text="${trace}"></td>
+        </tr>
+    </table>
+
+</div>
 <!-- /.container -->
 
 <div th:replace="~{fragments/footer :: footer}"/>


### PR DESCRIPTION
## Summary
Improves the WebWolf error page by displaying additional diagnostic details that can help users and contributors better understand runtime errors.

## Changes made
- Added an "Additional Information" section to `error.html`
- Included Spring-provided error attributes:
  - `error`
  - `message`
  - `trace`

## Why
The default error page already shows timestamp, path, and status, but adding more context makes the page more informative and useful for debugging.

## Related Issue
Closes #1740