### PR TITLE
Fixed bug in advanced SQL injection module never showing completed

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
@@ -8,8 +8,12 @@ import static org.owasp.webgoat.container.assignments.AttackResultBuilder.failed
 import static org.owasp.webgoat.container.assignments.AttackResultBuilder.informationMessage;
 import static org.owasp.webgoat.container.assignments.AttackResultBuilder.success;
 
-import java.sql.*;
-import lombok.extern.slf4j.Slf4j;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.owasp.webgoat.container.LessonDataSource;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AssignmentHints;
@@ -31,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
       "SqlInjectionChallenge6",
       "SqlInjectionChallenge7"
     })
-@Slf4j
+
 public class SqlInjectionChallenge implements AssignmentEndpoint {
 
   private final LessonDataSource dataSource;
@@ -49,7 +53,7 @@ public class SqlInjectionChallenge implements AssignmentEndpoint {
       @RequestParam("password_reg") String password) {
     AttackResult attackResult = checkArguments(username, email, password);
 
-    if (attackResult == null) {
+    if (attackResult.assignmentSolved()) {
 
       try (Connection connection = dataSource.getConnection()) {
         String checkUserQuery =

--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java
@@ -6,6 +6,7 @@ package org.owasp.webgoat.lessons.sqlinjection.advanced;
 
 import static org.owasp.webgoat.container.assignments.AttackResultBuilder.failed;
 import static org.owasp.webgoat.container.assignments.AttackResultBuilder.informationMessage;
+import static org.owasp.webgoat.container.assignments.AttackResultBuilder.success;
 
 import java.sql.*;
 import lombok.extern.slf4j.Slf4j;
@@ -84,6 +85,9 @@ public class SqlInjectionChallenge implements AssignmentEndpoint {
     if (username.length() > 250 || email.length() > 30 || password.length() > 30) {
       return failed(this).feedback("input.invalid").build();
     }
-    return null;
+
+    return success(this)
+        .feedback("User created successfully!")
+        .build();
   }
 }


### PR DESCRIPTION
### ISSUE
 Even after completing all lessons in the module, advanced SQL injection is never marked as completed in the report card.

### Fix
I figured out that the registration endpoint is being treated as a 5th lesson.

<img width="892" height="270" alt="20260401_16h39m48s_grim" src="https://github.com/user-attachments/assets/346a4cf4-2794-4191-b954-16f43bd51580" />

https://github.com/WebGoat/WebGoat/blob/7d3343d08c360d4751e5298e1fe910463b7731a1/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionChallenge.java#L78-L89

The registration endpoint lesson is never being marked as complete because this function returns `null` instead of an `AttackResult`.  

<img width="476" height="56" alt="20260402_09h12m32s_grim" src="https://github.com/user-attachments/assets/6d484954-b045-4c9b-aa9f-329fabc0a18b" />

 