### PR TITLE
Fixed hints not showing up for XXE lessons

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
@@ -64,7 +64,7 @@ public class BlindSendFileAssignment implements AssignmentEndpoint, Initializabl
     }
   }
 
-  @PostMapping(path = "xxe/blind", consumes = ALL_VALUE, produces = APPLICATION_JSON_VALUE)
+  @PostMapping(path = "/xxe/blind", consumes = ALL_VALUE, produces = APPLICATION_JSON_VALUE)
   @ResponseBody
   public AttackResult addComment(
       @RequestBody String commentStr, @AuthenticationPrincipal WebGoatUser user) {

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/ContentTypeAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/ContentTypeAssignment.java
@@ -42,7 +42,7 @@ public class ContentTypeAssignment implements AssignmentEndpoint {
     this.comments = comments;
   }
 
-  @PostMapping(path = "xxe/content-type")
+  @PostMapping(path = "/xxe/content-type")
   @ResponseBody
   public AttackResult createNewUser(
       @RequestBody String commentStr,

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/SimpleXXE.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/SimpleXXE.java
@@ -45,7 +45,7 @@ public class SimpleXXE implements AssignmentEndpoint {
     this.comments = comments;
   }
 
-  @PostMapping(path = "xxe/simple", consumes = ALL_VALUE, produces = APPLICATION_JSON_VALUE)
+  @PostMapping(path = "/xxe/simple", consumes = ALL_VALUE, produces = APPLICATION_JSON_VALUE)
   @ResponseBody
   public AttackResult createNewComment(
       @RequestBody String commentStr, @CurrentUser WebGoatUser user) {


### PR DESCRIPTION
Using a script I wrote to figure out why some JWT lessons were not showing hints, I was able to identify the same issue with some XXE lessons. This PR fixes the issue.
