### PR TITLE
Fixed issue where lessons do not turn green upon completion

### DIFF
--- a/src/main/resources/lessons/bypassrestrictions/html/BypassRestrictions.html
+++ b/src/main/resources/lessons/bypassrestrictions/html/BypassRestrictions.html
@@ -66,7 +66,7 @@
         <form class="attack-form" accept-charset="UNKNOWN" name="frontendValidation"
               id="frontendValidation"
               method="POST"
-              action="BypassRestrictions/frontendValidation"
+              th:action="@{/BypassRestrictions/frontendValidation}"
               onsubmit="return validate()">
             <div>
                 <strong>Field 1:</strong> exactly three lowercase characters(^[a-z]{3}$)

--- a/src/main/resources/lessons/clientsidefiltering/html/ClientSideFiltering.html
+++ b/src/main/resources/lessons/clientsidefiltering/html/ClientSideFiltering.html
@@ -83,7 +83,7 @@
         <div class="container-fluid">
             <form class="attack-form" accept-charset="UNKNOWN"
                   method="POST" name="form"
-                  action="clientSideFiltering/getItForFree">
+                  th:action="@{/clientSideFiltering/getItForFree}">
 
                 <input id="discount" type="hidden" value="0"/>
                 <div class="row">

--- a/src/main/resources/lessons/passwordreset/html/PasswordReset.html
+++ b/src/main/resources/lessons/passwordreset/html/PasswordReset.html
@@ -20,31 +20,6 @@
             <div class="row">
                 <div class="col-md-4">
 
-
-                    <form class="attack-form" accept-charset="UNKNOWN" novalidate="novalidate"
-                          method="POST"
-                          th:action="@{/PasswordReset/simple-mail/reset}">
-                        <div style="display: none;" id="password-reset-2">
-                            <h4 class="">Forgot your password?</h4>
-
-                            <fieldset>
-                                <span class="help-block">Please type your e-mail address</span>
-                                <div class="form-group input-group">
-                                    <span class="input-group-addon">@</span>
-                                    <input class="form-control" th:attr="placeholder=${username + '@webgoat.org'}" name="emailReset"
-                                           type="email"/>
-                                </div>
-                                <button type="submit" class="btn btn-primary btn-block" id="btn-olvidado">Continue
-                                </button>
-                                <p class="help-block">
-                                    <a class="text-muted" href="#" id="acceso" onclick="showPassword()">
-                                        <small>Account Access</small>
-                                    </a>
-                                </p>
-                            </fieldset>
-
-                        </div>
-                    </form>
                     <form class="attack-form" accept-charset="UNKNOWN" novalidate="novalidate"
                           method="POST"
                           th:action="@{/PasswordReset/simple-mail}">
@@ -78,6 +53,31 @@
 
                         </div>
                     </form>
+
+                    <form class="attack-form" accept-charset="UNKNOWN" novalidate="novalidate"
+                          method="POST"
+                          th:action="@{/PasswordReset/simple-mail/reset}">
+                        <div style="display: none;" id="password-reset-2">
+                            <h4 class="">Forgot your password?</h4>
+
+                            <fieldset>
+                                <span class="help-block">Please type your e-mail address</span>
+                                <div class="form-group input-group">
+                                    <span class="input-group-addon">@</span>
+                                    <input class="form-control" th:attr="placeholder=${username + '@webgoat.org'}" name="emailReset"
+                                           type="email"/>
+                                </div>
+                                <button type="submit" class="btn btn-primary btn-block" id="btn-olvidado">Continue
+                                </button>
+                                <p class="help-block">
+                                    <a class="text-muted" href="#" id="acceso" onclick="showPassword()">
+                                        <small>Account Access</small>
+                                    </a>
+                                </p>
+                            </fieldset>
+
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>
@@ -103,7 +103,7 @@
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
         <form class="attack-form" accept-charset="UNKNOWN"
               method="POST"
-              action="PasswordReset/questions">
+              th:action="@{/PasswordReset/questions}">
             <div class="container-fluid">
                 <div class="col-md-4">
                     <article class="card-body">
@@ -143,7 +143,7 @@
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
         <form class="attack-form" accept-charset="UNKNOWN"
               method="POST" name="form"
-              action="PasswordReset/SecurityQuestions">
+              th:action="@{/PasswordReset/SecurityQuestions}">
             <select name="question">
                 <option>What is your favorite animal?</option>
                 <option>In what year was your mother born?</option>
@@ -175,7 +175,7 @@
 
         <form class="attack-form" accept-charset="UNKNOWN"
               method="POST"
-              action="PasswordReset/reset/login">
+              th:action="@{/PasswordReset/reset/login}">
             <div class="container-fluid">
                 <div class="row">
                     <div class="col-md-4">
@@ -186,7 +186,7 @@
                         <div style="padding: 20px;" id="password-login">
                             <form id="login-form" class="attack-form" accept-charset="UNKNOWN"
                                   method="POST" name="form"
-                                  action="PasswordReset/reset/login"
+                                  th:action="@{/PasswordReset/reset/login}"
                                   role="form">
                                 <fieldset>
                                     <div class="form-group input-group">
@@ -222,7 +222,7 @@
                             </h4>
                             <form class="attack-form" accept-charset="UNKNOWN"
                                   method="POST" name="form"
-                                  action="PasswordReset/ForgotPassword/create-password-reset-link"
+                                  th:action="@{/PasswordReset/ForgotPassword/create-password-reset-link}"
                                   role="form">
                                 <fieldset>
         <span class="help-block">

--- a/src/main/resources/lessons/pathtraversal/html/PathTraversal.html
+++ b/src/main/resources/lessons/pathtraversal/html/PathTraversal.html
@@ -189,7 +189,7 @@
 
 
             <br/>
-            <form class="attack-form" method="POST" name="form" action="PathTraversal/random">
+            <form class="attack-form" method="POST" name="form" th:action="@{/PathTraversal/random}">
                 <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
                 <div class="form-group">
                     <div class="input-group">
@@ -227,7 +227,7 @@
 
                   prepareData="profileZipSlip"
                   enctype="multipart/form-data"
-                  action="PathTraversal/zip-slip">
+                  th:action="@{/PathTraversal/zip-slip}">
                 <div class="preview text-center">
                     <img class="preview-img" th:src="@{/images/account.png}" alt="Preview Image" width="200"
                          height="200" id="previewZipSlip"/>

--- a/src/main/resources/lessons/vulnerablecomponents/html/VulnerableComponents.html
+++ b/src/main/resources/lessons/vulnerablecomponents/html/VulnerableComponents.html
@@ -99,7 +99,7 @@
 			<div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
 			<form class="attack-form" accept-charset="UNKNOWN"
 				method="POST" name="form"
-				action="VulnerableComponents/attack1">
+				th:action="@{/VulnerableComponents/attack1}">
 				<div id="lessonContent">
 					<form accept-charset="UNKNOWN" method="POST" name="form"
 						action="#attack/307/100">

--- a/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
+++ b/src/main/resources/lessons/webwolfintroduction/html/WebWolfIntroduction.html
@@ -76,7 +76,7 @@
         <br/>
         <form class="attack-form" accept-charset="UNKNOWN"
               method="POST" name="form"
-              action="WebWolf/landing">
+              th:action="@{/WebWolf/landing}">
             <div class="container-fluid">
                 <div class="row">
                     <div class="col-md-4">


### PR DESCRIPTION
I recently noticed that a lot of lessons don't turn green upon completion. I wrote a script to identify these lessons and fixed them.

The issue appears to be in the action attribute of the attack form inside the lesson's HTML file. 
```diff
-              action="WebWolf/landing"> # Broken
+              th:action="@{/WebWolf/landing}"> #Fixed
```