### PR TITLE
Removed second slash on XXE blind assignment

### DIFF
--- a/src/main/resources/lessons/xxe/documentation/XXE_blind_assignment.adoc
+++ b/src/main/resources/lessons/xxe/documentation/XXE_blind_assignment.adoc
@@ -7,7 +7,7 @@ In the previous page we showed you how you can ping a server with a XXE attack, 
 |OS |Location
 
 |`operatingSystem:os[]`
-|`webGoatTempDir:temppath[]/XXE/username:user[]/secret.txt`
+|`webGoatTempDir:temppath[]XXE/username:user[]/secret.txt`
 
 |===
 


### PR DESCRIPTION
### Before
<img width="2146" height="502" alt="20260505_12h33m50s_grim" src="https://github.com/user-attachments/assets/81ac8f33-f8a0-45fb-9099-6243171cd56e" />

### After
<img width="2164" height="482" alt="20260505_12h31m55s_grim" src="https://github.com/user-attachments/assets/d900f4a8-3f39-4e03-9410-f8826e50cfdb" />

