### PR TITLE
Fixed a few vulnerabilities reported by zap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <commons-text.version>1.14.0</commons-text.version>
     <guava.version>33.5.0-jre</guava.version>
     <jacoco.version>0.8.11</jacoco.version>
-    <java.version>25</java.version>
+    <java.version>21</java.version>
     <jaxb.version>2.3.1</jaxb.version>
     <jjwt.version>0.9.1</jjwt.version>
     <jose4j.version>0.9.3</jose4j.version>

--- a/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -58,9 +59,28 @@ public class WebSecurityConfig {
               oidc.loginPage("/login");
             })
         .logout(logout -> logout.deleteCookies("JSESSIONID").invalidateHttpSession(true))
-        .csrf(csrf -> csrf.disable())
-        .headers(headers -> headers.disable())
-        .exceptionHandling(
+//        .csrf(csrf -> csrf.disable())
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/actuator/**"))
+//        .headers(headers -> headers.disable())
+            .headers(
+                    headers ->
+                            headers
+                                    .contentTypeOptions(contentTypeOptions -> {})
+                                    .contentSecurityPolicy(
+                                            csp ->
+                                                    csp.policyDirectives(
+                                                            "default-src 'self'; "
+                                                                    + "script-src 'self'; "
+                                                                    + "style-src 'self'; "
+                                                                    + "img-src 'self' data:; "
+                                                                    + "font-src 'self'; "
+                                                                    + "connect-src 'self'; "
+                                                                    + "frame-ancestors 'self'; "
+                                                                    + "object-src 'none'; "
+                                                                    + "base-uri 'self'; "
+                                                                    + "form-action 'self'"))
+                                    .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+            .exceptionHandling(
             handling ->
                 handling.authenticationEntryPoint(new AjaxAuthenticationEntryPoint("/login")))
         .build();

--- a/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig {
               auth.requestMatchers(HttpMethod.POST, "/files", "/mail", "/requests").permitAll();
               auth.anyRequest().authenticated();
             })
-        .csrf(csrf -> csrf.disable())
+        .csrf(csrf -> csrf.ignoringRequestMatchers("/files", "/mail", "/requests")) //csrf.disable()
         .formLogin(
             login ->
                 login
@@ -59,7 +59,25 @@ public class WebSecurityConfig {
               oidc.defaultSuccessUrl("/home");
             })
         .logout(logout -> logout.deleteCookies("WEBWOLFSESSION").invalidateHttpSession(true))
-        .exceptionHandling(
+            .headers(
+                    headers ->
+                            headers
+                                    .contentTypeOptions(contentTypeOptions -> {})
+                                    .contentSecurityPolicy(
+                                            csp ->
+                                                    csp.policyDirectives(
+                                                            "default-src 'self'; "
+                                                                    + "script-src 'self'; "
+                                                                    + "style-src 'self'; "
+                                                                    + "img-src 'self' data:; "
+                                                                    + "font-src 'self'; "
+                                                                    + "connect-src 'self'; "
+                                                                    + "frame-ancestors 'self'; "
+                                                                    + "object-src 'none'; "
+                                                                    + "base-uri 'self'; "
+                                                                    + "form-action 'self'"))
+                                    .frameOptions(frameOptions -> frameOptions.sameOrigin()))
+            .exceptionHandling(
             handling ->
                 handling.authenticationEntryPoint(new AjaxAuthenticationEntryPoint("/login")))
         .build();

--- a/src/main/resources/webgoat/templates/login.html
+++ b/src/main/resources/webgoat/templates/login.html
@@ -29,6 +29,7 @@
             </div>
             <br/><br/>
             <form th:action="@{/login}" method='POST' style="width: 200px;">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="form-group">
                     <label for="exampleInputEmail1" th:text="#{username}">Username</label>
                     <input autofocus="dummy_for_thymeleaf_parser" type="text" class="form-control"

--- a/src/main/resources/webgoat/templates/registration.html
+++ b/src/main/resources/webgoat/templates/registration.html
@@ -25,7 +25,7 @@
                 <legend th:text="#{register.title}">Please Sign Up</legend>
                 <form class="form-horizontal" action="#" th:action="@{/register.mvc}" th:object="${userForm}"
                       method='POST'>
-
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                     <div class="form-group" th:classappend="${#fields.hasErrors('username')}? 'has-error'">
                         <label for="username" class="col-sm-2 control-label" th:text="#{username}">Username</label>
                         <div class="col-sm-4">

--- a/src/main/resources/webwolf/templates/registration.html
+++ b/src/main/resources/webwolf/templates/registration.html
@@ -14,7 +14,7 @@
         <legend th:text="#{register.title}">Please Sign Up</legend>
         <form class="form-horizontal" action="#" th:action="@{/register.mvc}" th:object="${userForm}"
               method='POST'>
-
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <div class="form-group" th:classappend="${#fields.hasErrors('username')}? 'has-error'">
                 <label for="username" class="col-sm-2 control-label" th:text="#{username}">Username</label>
                 <div class="col-sm-4">

--- a/src/main/resources/webwolf/templates/webwolf-login.html
+++ b/src/main/resources/webwolf/templates/webwolf-login.html
@@ -14,6 +14,7 @@
     <div class="row" style="margin-top:100px">
         <div class="col-xs-12 col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3" th:style="'background:url(' + @{/images/wolf.png} + ') no-repeat right;'">
             <form th:action="@{/login}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <fieldset>
                     <h2>Sign in</h2>
                     <br/>


### PR DESCRIPTION
Content-Security-Policy header was missing.
Missing Anti-clickjacking Header
No Anti-CSRF tokens were found in a HTML submission form.
X-Content-Type-Options header was not set to nosniff.
