### PR TITLE
Cleanall

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ git checkout <<branch_name>>
 # On Windows:
 ./mvnw.cmd clean install
 
+If you have ran WebGoat before, you should first run mvn clean -Pcleanall to clean up files from your temp and home directories which could fail the tests due to changes in lessons!
+
 # Using docker or podman, you can than build the container locally
 docker build -f Dockerfile . -t webgoat/webgoat
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,43 @@
 
   <profiles>
     <profile>
+      <!-- run with: mvn clean -Pcleanall
+           Removes the runtime data directories (HSQLDB database + uploaded
+           files) that WebGoat leaves behind:
+             - ${user.home}/.webgoat-<version>      created by local runs
+             - ${java.io.tmpdir}/webgoat_<port>     created by integration tests
+           Stale data in the latter (e.g. assignments from older lesson
+           versions) can break the integration tests, so wiping it gives a
+           clean slate. Note this also discards saved lesson progress, which is
+           why it is not enabled by default. -->
+      <id>cleanall</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>${user.home}/.webgoat-${project.version}</directory>
+                </fileset>
+                <fileset>
+                  <directory>${java.io.tmpdir}</directory>
+                  <includes>
+                    <include>webgoat_*/**</include>
+                    <include>webgoat_*</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>local-server</id>
     </profile>
     <profile>


### PR DESCRIPTION
I needed this clean when switching to branches with changes in lessons which cause tests to fail if you switch back.
mvn clean -Pcleanall also cleans the parts created outside the project dir