### PR TITLE
refactor(it): static mutable user objects shared across test instances causing race condition

### DIFF
--- a/src/it/java/org/owasp/webgoat/playwright/webgoat/helpers/Authentication.java
+++ b/src/it/java/org/owasp/webgoat/playwright/webgoat/helpers/Authentication.java
@@ -28,17 +28,28 @@ public class Authentication {
     }
   }
 
-  @Getter private static User sylvester = new User("sylvester", "sylvester", null);
-  @Getter private static User tweety = new User("tweety", "tweety", null);
+  @Getter private static volatile User sylvester = new User("sylvester", "sylvester", null);
+  @Getter private static volatile User tweety = new User("tweety", "tweety", null);
+
+  private static final Object sylvesterLock = new Object();
+  private static final Object tweetyLock = new Object();
 
   public static Page sylvester(Browser browser) {
-    User user = login(browser, sylvester);
-    return browser.newContext(new Browser.NewContextOptions().setLocale("en-US").setStorageState(user.auth)).newPage();
+    synchronized (sylvesterLock) {
+      if (!sylvester.loggedIn()) {
+        sylvester = login(browser, sylvester);
+      }
+      return browser.newContext(new Browser.NewContextOptions().setLocale("en-US").setStorageState(sylvester.auth)).newPage();
+    }
   }
 
   public static Page tweety(Browser browser) {
-    User user = login(browser, tweety);
-    return browser.newContext(new Browser.NewContextOptions().setLocale("en-US").setStorageState(user.auth)).newPage();
+    synchronized (tweetyLock) {
+      if (!tweety.loggedIn()) {
+        tweety = login(browser, tweety);
+      }
+      return browser.newContext(new Browser.NewContextOptions().setLocale("en-US").setStorageState(tweety.auth)).newPage();
+    }
   }
 
   private static User login(Browser browser, User user) {


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The `sylvester` and `tweety` fields are static mutable `User` instances initialized with `auth = null`.
The `login()` method checks `user.loggedIn()` (which returns true if `auth != null`) but returns a NEW
User instance with the auth state, without updating the original static field. This means:

1. In parallel test execution, multiple threads could call `sylvester(browser)` simultaneously
2. Each call sees `auth == null` and creates a new registration + login flow
3. The first call returns and updates `auth` in its local copy, but the static field remains null
4. All subsequent calls still see `auth == null` and repeat registration

This causes test flakiness due to race conditions on WebGoat's user database and wastes resources
by creating multiple browser contexts/pages when only one was intended.


**Severity**: `medium`
**File**: `src/it/java/org/owasp/webgoat/playwright/webgoat/helpers/Authentication.java`

### Solution
Either make the static fields `volatile` and update them in the login methods, or change the design
to avoid shared mutable state. The simplest fix is to update the static fields:


### Changes
- `src/it/java/org/owasp/webgoat/playwright/webgoat/helpers/Authentication.java` (modified)

Thank you for submitting a pull request to the WebGoat!

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2473