### PR TITLE
fix(sqlinjection): correct target URLs for lesson 9 and 10 mitigations (#2246)

### DIFF
--- a/src/main/resources/lessons/sqlinjection/html/SqlInjectionMitigations.html
+++ b/src/main/resources/lessons/sqlinjection/html/SqlInjectionMitigations.html
@@ -72,7 +72,7 @@
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
         <form class="attack-form" accept-charset="UNKNOWN"
               method="POST" name="form"
-              th:action="@{/SqlInjectionMitigations/attack}"
+              th:action="@{/SqlOnlyInputValidation/attack}"
               enctype="application/json;charset=UTF-8">
             <table>
                 <tr>
@@ -95,7 +95,7 @@
         <div class="assignment-success"><i class="fa fa-2 fa-check hidden" aria-hidden="true"></i></div>
         <form class="attack-form" accept-charset="UNKNOWN"
               method="POST" name="form"
-              th:action="@{/SqlInjectionMitigations/attack}"
+              th:action="@{/SqlOnlyInputValidationOnKeywords/attack}"
               enctype="application/json;charset=UTF-8">
             <table>
                 <tr>


### PR DESCRIPTION
## Summary

Closes #2246

This PR fixes the form submission endpoints for Questions 9 and 10 in the `SqlInjectionMitigations` lesson.

Both forms were configured to submit requests to:

```
/SqlInjectionMitigations/attack
```

which does not handle these exercises and results in a `404 Not Found` response. Consequently, pressing the **Submit** button had no visible effect, preventing users from completing the lesson.

The issue was caused by incorrect `th:action` attributes in the lesson's Thymeleaf template.

## Changes

- Updated Question 9 to submit to:
  - `/SqlOnlyInputValidation/attack`
- Updated Question 10 to submit to:
  - `/SqlOnlyInputValidationOnKeywords/attack`

## Result

After these changes:

- Question 9 submits to the correct input validation endpoint.
- Question 10 submits to the correct keyword validation endpoint.
- The forms no longer return a 404 response.
- Users can successfully complete both mitigation exercises as intended.

## Testing

- Verified that both forms now generate POST requests to the expected endpoints.
- Confirmed that the previous `404 Not Found` error no longer occurs.
- Confirmed that the lesson behaves as expected after updating the form actions.
