### PR TITLE
doc and change for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,37 +30,16 @@ jobs:
           mvn --no-transfer-progress versions:set -DnewVersion=${{ env.WEBGOAT_MAVEN_VERSION }}
           mvn --no-transfer-progress install -DskipTests
 
+      # Published as a draft so the generated notes can be reviewed and edited before they go public,
+      # the release itself is created with the notes GitHub derives from the merged pull requests
+      # since the previous tag.
       - name: "Create release"
         uses: softprops/action-gh-release@v3
         with:
-          draft: false
+          draft: true
+          generate_release_notes: true
           files: |
             target/webgoat-${{ env.WEBGOAT_MAVEN_VERSION }}.jar
-          body: |
-           ## Version ${{ github.ref_name }}
-
-            ### New functionality
-
-            - test
-
-            ### Bug fixes
-
-            - [#743 - Character encoding errors](https://github.com/WebGoat/WebGoat/issues/743)
-
-            Full change log: https://github.com/WebGoat/WebGoat/compare/${{ github.ref_name }}...${{ github.ref_name }}
-
-
-            ## Contributors
-
-            Special thanks to the following contributors providing us with a pull request:
-
-            - Person 1
-            - Person 2
-
-            And everyone who provided feedback through Github.
-
-
-            Team WebGoat
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -108,9 +87,15 @@ jobs:
     name: Update to next SNAPSHOT version
     needs: [ release ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
+      # The workflow is triggered by a tag, checking out main makes sure the branch we push and the
+      # pull request we open only contain the version bump.
       - uses: actions/checkout@v7
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Set up JDK
@@ -118,21 +103,23 @@ jobs:
         with:
           cache: ''
 
+      # nextMinorVersion and not minorVersion: the released pom is 2026.2, development continues on
+      # 2026.3-SNAPSHOT.
       - name: Set version to next snapshot
         run: |
-          mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}-SNAPSHOT versions:commit
+          mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}-SNAPSHOT versions:commit
 
       - name: Push the changes to new branch
         uses: devops-infra/action-commit-push@v1.5.0
         with:
             github_token: "${{ secrets.GITHUB_TOKEN }}"
             add_timestamp: true
-            commit_message: "Updating to the new development version"
+            commit_message: "chore: back to snapshot after ${{ github.ref_name }}"
             force: false
 
       - name: Create PR
         uses: devops-infra/action-pull-request@v1.4.0
         with:
             github_token: "${{ secrets.GITHUB_TOKEN }}"
-            title: ${{ github.event.commits[0].message }}
+            title: "chore: back to snapshot after ${{ github.ref_name }}"
             target_branch: main

--- a/release-explained.md
+++ b/release-explained.md
@@ -1,0 +1,115 @@
+# Release explained
+
+How a WebGoat release is cut with [`.github/workflows/release.yml`](.github/workflows/release.yml), what the
+pipeline does on its own, and what still has to be done by hand afterwards.
+
+The description below matches how the previous releases were actually made: a commit
+`chore: new release 2025.3`, the tag `v2025.3`, and afterwards a manual `chore: back to snapshot` commit.
+
+## Starting a release
+
+The only trigger is a tag push matching `v*`:
+
+```yaml
+on:
+  push:
+    tags:
+      - v*
+```
+
+With the pom at `2026.2-SNAPSHOT`, the next release is `v2026.2`:
+
+```bash
+# 1. main is green and everything you want in the release is merged
+
+# 2. add a "## Version 2026.2" section to RELEASE_NOTES.md
+
+# 3. drop the -SNAPSHOT
+mvn versions:set -DnewVersion=2026.2 versions:commit
+git commit -am "chore: new release 2026.2"
+git push origin main
+
+# 4. this is what actually starts the pipeline
+git tag v2026.2
+git push origin v2026.2
+```
+
+### Tagging without the release commit
+
+Steps 2 and 3 are convention, not a hard requirement. The workflow runs its own `versions:set` before
+building, so the jar and the docker tags are correct whatever the pom on `main` says, and the
+`new_version` job derives `2026.3-SNAPSHOT` from `2026.2-SNAPSHOT` just as well as from `2026.2`. Picking
+a commit on `main` and pushing a tag for it is enough to release:
+
+```bash
+git tag v2026.2 <sha>
+git push origin v2026.2
+```
+
+That also avoids writing to `main` directly, which matters when the branch is protected — the only change
+the pipeline makes to `main` is through the pull request of the `new_version` job.
+
+What you give up is that the tagged source does not state the version it was released as:
+`git show v2026.2:pom.xml` says `2026.2-SNAPSHOT`, and building the tag locally produces
+`webgoat-2026.2-SNAPSHOT.jar` instead of the released `webgoat-2026.2.jar`. Reproducing the release from
+source then means knowing to run `versions:set` first. Keeping [RELEASE_NOTES.md](RELEASE_NOTES.md)
+up to date also becomes a separate pull request instead of part of the release commit.
+
+Note that the `new_version` job always computes the next version from the current pom on `main`, not from
+the commit you tagged. That is only a problem if you tag an older commit while `main` has already moved on
+to a different minor version.
+
+### Things that will bite you
+
+| What                                 | Why                                                                                                                                                                |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| The tag name *is* the version        | `WEBGOAT_MAVEN_VERSION=${WEBGOAT_TAG_VERSION:1}` strips the first character. `v2026.2` → `2026.2`. A tag without the `v` never triggers, and `vtest10` would build maven version `test10`. |
+| It does not run on a fork            | Both jobs are guarded by `if: github.repository == 'WebGoat/WebGoat'`.                                                                                              |
+| The `release` environment            | The job uses `environment: name: release`. Required reviewers make it wait for approval, and `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` must be available there.       |
+| No tests are run                     | The build is `mvn install -DskipTests`, so the build on `main` is the only gate.                                                                                     |
+
+## What the workflow does
+
+1. Checks out the tag, sets up Temurin 25 through [`.github/actions/java-setup`](.github/actions/java-setup).
+2. `mvn versions:set -DnewVersion=2026.2` followed by `mvn install -DskipTests`.
+3. Creates a **draft** GitHub release with `target/webgoat-2026.2.jar` attached and notes generated from
+   the pull requests merged since the previous tag.
+4. Builds and pushes multi-arch (amd64 + arm64) images to Docker Hub:
+   - `webgoat/webgoat:v2026.2` and `webgoat/webgoat:latest`
+   - `webgoat/webgoat-desktop:v2026.2` and `webgoat/webgoat-desktop:latest`
+5. Runs the `new_version` job, which opens a pull request against `main` moving the pom to the next
+   development version (`2026.3-SNAPSHOT`).
+
+The docker tags keep the `v` prefix, the jar and the maven version do not.
+
+## What has to happen after the workflow
+
+### 1. Review and publish the draft release
+
+The release is created as a draft, so nothing is public until someone presses *Publish release*. Check the
+generated notes, fold in the [RELEASE_NOTES.md](RELEASE_NOTES.md) section for the version if you want the
+curated wording, and publish.
+
+### 2. Merge the bump pull request
+
+The `new_version` job opens a pull request against `main` titled
+`chore: back to snapshot after v2026.2`, containing only the pom move to `2026.3-SNAPSHOT`. Review and
+merge it.
+
+### 3. Verify the artifacts
+
+- the jar is attached to the GitHub release
+- both images are on Docker Hub with the new tag and with `latest`
+
+```bash
+docker run -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:9090:9090 webgoat/webgoat:v2026.2
+```
+
+### 4. Make sure `main` is on the next snapshot
+
+Once the pull request from step 2 is merged, `main` is on `2026.3-SNAPSHOT`. If that pull request never
+appeared or failed, push the bump yourself — otherwise the next release repeats the previous version and
+the whole scheme drifts.
+
+The changes behind steps 1 and 2 are described in
+[release-workflow-changes.md](release-workflow-changes.md).

--- a/release-explained.md
+++ b/release-explained.md
@@ -61,12 +61,12 @@ to a different minor version.
 
 ### Things that will bite you
 
-| What                                 | Why                                                                                                                                                                |
-|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| The tag name *is* the version        | `WEBGOAT_MAVEN_VERSION=${WEBGOAT_TAG_VERSION:1}` strips the first character. `v2026.2` → `2026.2`. A tag without the `v` never triggers, and `vtest10` would build maven version `test10`. |
-| It does not run on a fork            | Both jobs are guarded by `if: github.repository == 'WebGoat/WebGoat'`.                                                                                              |
-| The `release` environment            | The job uses `environment: name: release`. Required reviewers make it wait for approval, and `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` must be available there.       |
-| No tests are run                     | The build is `mvn install -DskipTests`, so the build on `main` is the only gate.                                                                                     |
+|             What              |                                                                                            Why                                                                                             |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| The tag name *is* the version | `WEBGOAT_MAVEN_VERSION=${WEBGOAT_TAG_VERSION:1}` strips the first character. `v2026.2` → `2026.2`. A tag without the `v` never triggers, and `vtest10` would build maven version `test10`. |
+| It does not run on a fork     | Both jobs are guarded by `if: github.repository == 'WebGoat/WebGoat'`.                                                                                                                     |
+| The `release` environment     | The job uses `environment: name: release`. Required reviewers make it wait for approval, and `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` must be available there.                             |
+| No tests are run              | The build is `mvn install -DskipTests`, so the build on `main` is the only gate.                                                                                                           |
 
 ## What the workflow does
 


### PR DESCRIPTION
# Changes to the release workflow

What was changed in [`.github/workflows/release.yml`](.github/workflows/release.yml) and why. The
end-to-end description of a release lives in [release-explained.md](release-explained.md).

## 1. The release notes are generated instead of hardcoded

**Was:** the `Create release` step carried a fixed `body:` which was published immediately
(`draft: false`). Every release therefore went public with the same placeholder text: `### New
functionality` containing a single `- test` entry, a bug fix section linking to
[#743](https://github.com/WebGoat/WebGoat/issues/743) from 2023, "Person 1" and "Person 2" as
contributors, and a change log link comparing the tag with itself
(`compare/v2026.2...v2026.2`), which renders as an empty diff. The description had to be rewritten by
hand after every release.

**Is:**

```yaml
      - name: "Create release"
        uses: softprops/action-gh-release@v3
        with:
          draft: true
          generate_release_notes: true
          files: |
            target/webgoat-${{ env.WEBGOAT_MAVEN_VERSION }}.jar
```

`generate_release_notes: true` lets GitHub build the notes from the pull requests merged since the
previous tag, which is what the conventional commit style in
[CONTRIBUTING.md](CONTRIBUTING.md) is for. The stub `body:` is gone.

**This changes the release procedure:** `draft: true` means the release is no longer published by the
pipeline. It is created as a draft with the jar attached, and someone has to review the generated notes
and press *Publish release*. That is deliberate — it is the moment to fold in the
[RELEASE_NOTES.md](RELEASE_NOTES.md) section for the version — but it does mean a release now needs a
manual final step. Dropping `draft: true` restores automatic publishing while keeping the generated
notes.

## 2. The next development version is actually the next one

**Was:**

```yaml
mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}-SNAPSHOT versions:commit
```

`minorVersion` is the minor of the version that was just released, so releasing `2026.2` produced
`2026.2-SNAPSHOT` — the same minor, over and over. The pull request opened by the job contained no
useful change, and the real bump was done by hand in a `chore: back to snapshot` commit.

**Is:** `${parsedVersion.nextMinorVersion}`, so `2026.2` is followed by `2026.3-SNAPSHOT`.

## 3. The job checks out `main` instead of the tag

**Was:** a plain `actions/checkout@v7`, which for a tag push checks out the tag in detached HEAD. The
branch pushed by the job was based on the tag rather than on `main`.

**Is:** `ref: main`. The branch and the resulting pull request now contain only the version bump,
relative to the branch it targets.

## 4. The job has the permissions it needs

**Was:** no `permissions:` block on `new_version`, so the job ran with the repository default for
`GITHUB_TOKEN`. If that default is read-only — the recommended setting, and the reason the `release` job
declares `contents: write` — pushing the branch and opening the pull request fail with a 403.

**Is:**

```yaml
    permissions:
      contents: write
      pull-requests: write
```

## 5. The pull request has a title

**Was:** `title: ${{ github.event.commits[0].message }}`. The push event for a tag carries no commits, so
the expression resolves to an empty string. The commit message was the equally unhelpful
`Updating to the new development version`.

**Is:** both the commit message and the pull request title are
`chore: back to snapshot after ${{ github.ref_name }}`, which follows the conventional commit style used
in the repository and names the release it belongs to.

## Not changed

- **The docker image tags still keep the `v`.** `webgoat/webgoat:v2026.2` while the jar is
  `webgoat-2026.2.jar`. It is inconsistent, but it is how every published image is tagged today and
  changing it would break anyone pinning a version.
- **The release build still runs `-DskipTests`.** The build on `main` remains the only gate.
- **The fork guard (`if: github.repository == 'WebGoat/WebGoat'`) is untouched**, so testing the pipeline
  on a fork still requires removing it locally.

## Verification

The changes have not been exercised by an actual release — that needs a tag push on the upstream
repository. Worth confirming on the next release:

- the draft release is created with the jar attached and sensible generated notes
- the `new_version` pull request targets `main`, is titled, and moves the pom to the next minor snapshot
